### PR TITLE
Fix favorites mapping in dashboard

### DIFF
--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -78,7 +78,7 @@ function Dashboard() {
         const res = await axios.get('/api/favorites', {
           headers: { Authorization: `Bearer ${token}` }
         });
-        setFavorites(res.data.map(fav => fav._id));
+        setFavorites(res.data.map(fav => fav.propertyId._id));
       } catch (err) {
         console.error('Error fetching favorites', err);
       }


### PR DESCRIPTION
## Summary
- correctly store property IDs when fetching favorites

## Testing
- `cd frontend && npm test` (fails: Error: no test specified)
- `cd backend && npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_6890624d94f4832296c7f9111849b4fc