### PR TITLE
feat: alert tenants when favorite property is removed

### DIFF
--- a/backend/models/notification.js
+++ b/backend/models/notification.js
@@ -11,6 +11,9 @@ const notificationSchema = new mongoose.Schema({
     enum: ["interest", "message", "appointment","property_removed"],
     required: true,
   },
+  message: {
+    type: String,
+  },
   referenceId: {
     type: mongoose.Schema.Types.ObjectId,
     required: true,

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -181,11 +181,12 @@ function Dashboard() {
                   <ul className="list-unstyled mb-0">
                     {notifications.map((note, idx) => (
                       <li key={idx} className="border-bottom py-2">
-                        {note.type === "interest" && "Someone added your property to favorites."}
-                        {note.type === "property_removed" && "A property you have added to your favorites has been removed."}
-                        {note.type === "message" && "You have a new message."}
-                        {note.type === "appointment" && "you have a new appointment."}
-                        {!["interest", "property_removed", "message", "appointment"].includes(note.type) && "Νέα ειδοποίηση."}
+                        {note.message ||
+                          (note.type === "interest" && "Someone added your property to favorites.") ||
+                          (note.type === "property_removed" && "A property you have added to your favorites has been removed.") ||
+                          (note.type === "message" && "You have a new message.") ||
+                          (note.type === "appointment" && "you have a new appointment.") ||
+                          "Νέα ειδοποίηση."}
                       </li>
                     ))}
                   </ul>


### PR DESCRIPTION
## Summary
- notify tenants when an owner deletes a property they had favorited
- store optional messages on notifications
- surface backend message text in dashboard notifications
- ensure property deletion creates notifications for distinct favoriting tenants

## Testing
- `npm test` (backend) *(fails: no test specified)*
- `npm test` (frontend) *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689101e9dd348322984d131b73e33696