### PR TITLE
feat: add notifications for favorites and deletions

### DIFF
--- a/backend/controllers/favoritesController.js
+++ b/backend/controllers/favoritesController.js
@@ -21,7 +21,7 @@ const addFavorite = async (req, res) => {
     if (ownerId && ownerId.toString() !== userId) {
       await Notification.create({
         userId: ownerId,
-        type: "interest",
+        type: "favorite",
         referenceId: property._id,
       });
     }

--- a/backend/models/notification.js
+++ b/backend/models/notification.js
@@ -8,7 +8,7 @@ const notificationSchema = new mongoose.Schema({
   },
   type: {
     type: String,
-    enum: ["interest", "message", "appointment","property_removed"],
+    enum: ["interest", "message", "appointment", "property_removed", "favorite"],
     required: true,
   },
   referenceId: {

--- a/frontend/src/components/NotificationDropdown.js
+++ b/frontend/src/components/NotificationDropdown.js
@@ -25,7 +25,11 @@ function NotificationDropdown({ notifications, onClose }) {
         <ul className="list-unstyled mb-0">
           {notifications.map((note, idx) => (
             <li key={idx} className="border-bottom py-2">
-              {note.message}
+              {(["favorite", "interest"].includes(note.type) && "Someone added your property to favorites.") ||
+               (note.type === "property_removed" && "A property you have added to your favorites has been removed.") ||
+               (note.type === "message" && "You have a new message.") ||
+               (note.type === "appointment" && "you have a new appointment.") ||
+               "Νέα ειδοποίηση."}
             </li>
           ))}
         </ul>

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -181,11 +181,11 @@ function Dashboard() {
                   <ul className="list-unstyled mb-0">
                     {notifications.map((note, idx) => (
                       <li key={idx} className="border-bottom py-2">
-                        {note.type === "interest" && "Someone added your property to favorites."}
+                        {(["favorite", "interest"].includes(note.type)) && "Someone added your property to favorites."}
                         {note.type === "property_removed" && "A property you have added to your favorites has been removed."}
                         {note.type === "message" && "You have a new message."}
                         {note.type === "appointment" && "you have a new appointment."}
-                        {!["interest", "property_removed", "message", "appointment"].includes(note.type) && "Νέα ειδοποίηση."}
+                        {!["favorite", "interest", "property_removed", "message", "appointment"].includes(note.type) && "Νέα ειδοποίηση."}
                       </li>
                     ))}
                   </ul>


### PR DESCRIPTION
## Summary
- notify owners with `favorite` notifications when tenants favorite their property
- map notification types to user-friendly messages in dashboard dropdown

## Testing
- `npm test` (backend) *(fails: no test specified)*
- `npm test` (frontend) *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689110ce5ee483228117bce1ae6aa92f