### PR TITLE
Ensure favorite notifications include owner

### DIFF
--- a/backend/models/notification.js
+++ b/backend/models/notification.js
@@ -8,12 +8,19 @@ const notificationSchema = new mongoose.Schema({
   },
   type: {
     type: String,
-    enum: ["interest", "message", "appointment","property_removed"],
+    enum: ["interest", "message", "appointment", "property_removed", "favorite"],
     required: true,
   },
   referenceId: {
     type: mongoose.Schema.Types.ObjectId,
     required: true,
+  },
+  tenantName: {
+    type: String,
+  },
+  favoritedAt: {
+    type: Date,
+    default: Date.now,
   },
   read: {
     type: Boolean,


### PR DESCRIPTION
## Summary
- ensure property owner is fetched before creating favorite notifications
- include tenant name and timestamp when creating favorite notifications
- create favorite notification referencing propertyId
- log errors when notification creation fails

## Testing
- `cd backend && npm test` *(fails: Error: no test specified)*
- `cd frontend && npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_689113ecb238832293aafc297d91ee0f