### PR TITLE
Notify owners when properties are favorited with tenant details

### DIFF
--- a/backend/controllers/favoritesController.js
+++ b/backend/controllers/favoritesController.js
@@ -1,5 +1,4 @@
 const Favorites = require("../models/favorites");
-const User = require("../models/user");
 const Notification = require("../models/notification");
 const Property = require("../models/property");
 const addFavorite = async (req, res) => {
@@ -23,6 +22,7 @@ const addFavorite = async (req, res) => {
         userId: ownerId,
         type: "interest",
         referenceId: property._id,
+        senderId: userId
       });
     }
 

--- a/backend/controllers/notificationController.js
+++ b/backend/controllers/notificationController.js
@@ -5,7 +5,9 @@ exports.getNotifications = async (req, res) => {
   const userId = req.user.userId;
 
   try {
-    const notifications = await Notification.find({ userId }).sort({ createdAt: -1 });
+    const notifications = await Notification.find({ userId })
+      .sort({ createdAt: -1 })
+      .populate('senderId', 'name');
     res.json(notifications);
   } catch (err) {
     res.status(500).json({ message: "Server error" });

--- a/backend/models/notification.js
+++ b/backend/models/notification.js
@@ -15,6 +15,10 @@ const notificationSchema = new mongoose.Schema({
     type: mongoose.Schema.Types.ObjectId,
     required: true,
   },
+  senderId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "User",
+  },
   read: {
     type: Boolean,
     default: false,

--- a/frontend/src/components/NotificationDropdown.js
+++ b/frontend/src/components/NotificationDropdown.js
@@ -25,7 +25,15 @@ function NotificationDropdown({ notifications, onClose }) {
         <ul className="list-unstyled mb-0">
           {notifications.map((note, idx) => (
             <li key={idx} className="border-bottom py-2">
-              {note.message}
+              {note.type === 'interest' && (
+                <span>
+                  {note.senderId?.name || 'Someone'} added your property to favorites at {new Date(note.createdAt).toLocaleString()}.
+                </span>
+              )}
+              {note.type === 'property_removed' && 'A property you have added to your favorites has been removed.'}
+              {note.type === 'message' && 'You have a new message.'}
+              {note.type === 'appointment' && 'you have a new appointment.'}
+              {!['interest', 'property_removed', 'message', 'appointment'].includes(note.type) && 'Νέα ειδοποίηση.'}
             </li>
           ))}
         </ul>

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -181,7 +181,11 @@ function Dashboard() {
                   <ul className="list-unstyled mb-0">
                     {notifications.map((note, idx) => (
                       <li key={idx} className="border-bottom py-2">
-                        {note.type === "interest" && "Someone added your property to favorites."}
+                        {note.type === "interest" && (
+                          <span>
+                            {note.senderId?.name || 'Someone'} added your property to favorites at {new Date(note.createdAt).toLocaleString()}.
+                          </span>
+                        )}
                         {note.type === "property_removed" && "A property you have added to your favorites has been removed."}
                         {note.type === "message" && "You have a new message."}
                         {note.type === "appointment" && "you have a new appointment."}


### PR DESCRIPTION
## Summary
- Track the tenant who favorites a property by storing `senderId` on notifications
- Populate tenant name in notification API responses
- Display tenant name and time when a property is favorited in dashboard notifications

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6891189f01d4832299d8aef7c2e53c1a