### PR TITLE
feat: support profile picture uploads

### DIFF
--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -79,6 +79,10 @@ exports.updateUserProfile = async (req, res) => {
       salary: req.body.salary
     };
 
+    if (req.file) {
+      updates.profilePicture = `/uploads/${req.file.filename}`;
+    }
+
     const updatedUser = await User.findByIdAndUpdate(
       userId,
       { $set: updates },

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -25,9 +25,10 @@ const userSchema =  new mongoose.Schema({
         enum: ["client", "owner"], 
         default: "client", 
     }, 
-    address: String, 
+    address: String,
     occupation: String,
     salary: Number,
+    profilePicture: String,
     favorites: [
     {
         type: mongoose.Schema.Types.ObjectId,

--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -4,6 +4,7 @@ const User = require("../models/user");
 const userController = require("../controllers/userController");
 const verifyToken = require("../middlewares/authMiddleware");
 const {updateUserProfile} = require("../controllers/userController");
+const upload = require("../middlewares/uploadMiddleware");
 
 //register 
 router.post("/register", userController.registerUser);
@@ -15,7 +16,7 @@ router.post("/login", userController.loginUser);
 router.get("/profile", verifyToken, userController.getUserProfile);
 
 //update profile
-router.put("/profile", verifyToken, userController.updateUserProfile);
+router.put("/profile", verifyToken, upload.single("profilePicture"), userController.updateUserProfile);
 
 //router.post('/favorites/:propertyId', verifyToken, userController.toggleFavorite);
 

--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -34,6 +34,7 @@ export const AuthProvider = ({ children }) => {
             address: data.address,
             occupation: data.occupation,
             salary: data.salary,
+            profilePicture: data.profilePicture,
           });
         } else {
           console.warn(' Unauthorized or failed profile fetch');

--- a/frontend/src/pages/EditProfile.js
+++ b/frontend/src/pages/EditProfile.js
@@ -2,15 +2,14 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { Button } from 'react-bootstrap';
-import { setUser } from '../context/AuthContext'; // Assuming you have a setUser function to update user state
 
 
 function EditProfile() {
   const { user,setUser } = useAuth();
   const navigate = useNavigate();
-  
 
-  // forma me stoixeia tou xrhsth 
+
+  // forma me stoixeia tou xrhsth
   const [formData, setFormData] = useState({
     name: '',
     phone: '',
@@ -18,6 +17,8 @@ function EditProfile() {
     occupation: '',
     salary: '',
   });
+
+  const [profilePicture, setProfilePicture] = useState(null);
 
   const [message, setMessage] = useState('');
 
@@ -49,13 +50,20 @@ function EditProfile() {
     const token = localStorage.getItem('token');
 
     try {
+      const submissionData = new FormData();
+      Object.entries(formData).forEach(([key, value]) => {
+        submissionData.append(key, value);
+      });
+      if (profilePicture) {
+        submissionData.append('profilePicture', profilePicture);
+      }
+
       const response = await fetch('/api/user/profile', {
         method: 'PUT',
         headers: {
-          'Content-Type': 'application/json',
           Authorization: `Bearer ${token}`,
         },
-        body: JSON.stringify(formData),
+        body: submissionData,
       });
 
       if (response.ok) {
@@ -144,6 +152,16 @@ function EditProfile() {
             className="form-control"
             value={formData.salary}
             onChange={handleChange}
+          />
+        </div>
+
+        <div className="mb-3">
+          <label>Profile Picture</label>
+          <input
+            type="file"
+            className="form-control"
+            accept="image/*"
+            onChange={(e) => setProfilePicture(e.target.files[0])}
           />
         </div>
 

--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -20,6 +20,16 @@ function Profile() {
           <h3>👤 User Profile</h3>
         </Card.Header>
         <Card.Body>
+          {user?.profilePicture && (
+            <div className="text-center mb-3">
+              <img
+                src={user.profilePicture}
+                alt="Profile"
+                className="img-fluid rounded-circle"
+                style={{ width: '150px', height: '150px', objectFit: 'cover' }}
+              />
+            </div>
+          )}
           <p><strong>Name:</strong> {user?.name}</p>
           <p><strong>Email:</strong> {user?.email}</p>
           <p><strong>Type:</strong> {user?.role}</p>

--- a/frontend/src/services/userService.js
+++ b/frontend/src/services/userService.js
@@ -14,7 +14,7 @@ export const getUserProfile = async()=>{
 
 export const updateUserProfile = async(updatedData)=>{
     const token = localStorage.getItem('token');
-    const res = await axios.put(`${API_BASE}/profile`, updatedData,{
+    const res = await axios.put(`${API_BASE}/profile`, updatedData, {
         headers: {
             Authorization: `Bearer ${token}`
         }


### PR DESCRIPTION
## Summary
- add `profilePicture` field to users
- allow uploading a profile image when updating profile
- show stored profile image in profile page

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm test` (frontend) *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68935b70e2b08322ab3a93c2cffa0d72