### PR TITLE
Fix user account deletion via API cleanup

### DIFF
--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -1,26 +1,32 @@
 const express = require("express");
 const router = express.Router();
-const User = require("../models/user");
+
+// Controllers
 const userController = require("../controllers/userController");
+
+// Middlewares
 const verifyToken = require("../middlewares/authMiddleware");
-const {updateUserProfile} = require("../controllers/userController");
-const authMiddleware = require("../middlewares/authMiddleware");
 const upload = require("../middlewares/uploadMiddleware");
-const {deleteUserAccount} = require("../controllers/userController");
-//register 
+
+// Register
 router.post("/register", userController.registerUser);
 
-//login
+// Login
 router.post("/login", userController.loginUser);
 
-//get profile
+// Get profile
 router.get("/profile", verifyToken, userController.getUserProfile);
 
-//update profile
-router.put("/profile", verifyToken, upload.single("profilePicture"), userController.updateUserProfile);
-//router.post('/favorites/:propertyId', verifyToken, userController.toggleFavorite);
+// Update profile
+router.put(
+  "/profile",
+  verifyToken,
+  upload.single("profilePicture"),
+  userController.updateUserProfile
+);
 
-router.delete('/profile',authMiddleware,deleteUserAccount);
-
+// Delete profile
+router.delete("/profile", verifyToken, userController.deleteUserAccount);
 
 module.exports = router;
+

--- a/frontend/src/pages/EditProfile.js
+++ b/frontend/src/pages/EditProfile.js
@@ -64,7 +64,7 @@ function EditProfile() {
     }
 
     try {
-      const response = await fetch('http://localhost:5000/api/user/profile', {
+      const response = await fetch('/api/user/profile', {
         method: 'PUT',
         headers: {
           Authorization: `Bearer ${token}`
@@ -94,10 +94,11 @@ function EditProfile() {
     if (!confirmDelete) return;
 
     try {
-      const response = await fetch('http://localhost:5000/api/user/profile', {
+      const response = await fetch('/api/user/profile', {
         method: 'DELETE',
         headers: {
-          Authorization: `Bearer ${localStorage.getItem('token')}`
+          Authorization: `Bearer ${localStorage.getItem('token')}`,
+          'Content-Type': 'application/json'
         }
       });
 


### PR DESCRIPTION
## Summary
- streamline user routes and secure delete endpoint with verifyToken
- use relative API URLs and proper headers when updating or deleting profile

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68949388f9ac8322ba1e26139b4d746e