### PR TITLE
feat: add multi-date proposals for interests

### DIFF
--- a/backend/controllers/interestController.js
+++ b/backend/controllers/interestController.js
@@ -89,6 +89,66 @@ exports.getInterestById = async (req, res) => {
 };
 
 /**
+ * Owner proposes multiple dates for an interest
+ * POST /api/interests/:id/proposals
+ * body: { dates: string[] }
+ */
+exports.proposeDates = async (req, res) => {
+  try {
+    const { dates } = req.body || {};
+    const interest = await Interest.findById(req.params.id).populate("propertyId");
+    if (!interest) return res.status(404).json({ message: "Interest not found" });
+
+    if (String(interest.propertyId.ownerId) !== String(req.user.userId)) {
+      return res.status(403).json({ message: "Forbidden" });
+    }
+
+    if (!Array.isArray(dates) || dates.length === 0) {
+      return res.status(400).json({ message: "dates array required" });
+    }
+
+    // normalize, validate and dedupe
+    const unique = new Set(
+      dates
+        .map((d) => {
+          const date = new Date(d);
+          return isNaN(date.getTime()) ? null : date.getTime();
+        })
+        .filter((ts) => ts !== null)
+    );
+
+    if (unique.size === 0) {
+      return res.status(400).json({ message: "No valid dates provided" });
+    }
+
+    const existing = new Set(interest.proposedDates.map((d) => +d));
+    for (const ts of unique) {
+      if (!existing.has(ts)) {
+        interest.proposedDates.push(new Date(ts));
+      }
+    }
+
+    await interest.save();
+
+    await sendNotification({
+      userId: interest.tenantId,
+      senderId: req.user.userId,
+      type: "interest_proposed",
+      referenceId: interest._id,
+      message: "New proposed dates have been added for your interest.",
+    });
+
+    const updated = await Interest.findById(interest._id)
+      .populate("tenantId", "name email phone")
+      .populate("propertyId", "title location ownerId");
+    res.json({ message: "Dates proposed", interest: updated });
+  } catch (err) {
+    console.error("❌ Propose dates error:", err);
+    res.status(500).json({ message: "Server error" });
+  }
+};
+
+/**
  * Owner updates interest status (+ optional preferredDate)
  * Supports BOTH:
  *   PUT   /api/interests/:interestId
@@ -96,11 +156,8 @@ exports.getInterestById = async (req, res) => {
  * body: { status: 'accepted' | 'declined' | 'pending', preferredDate?: Date|string|null }
  *
  * Notifies tenant on accepted/declined.
- * If status stays "pending" but preferredDate changes, sends "interest_proposed".
  */
 exports.updateInterestStatus = async (req, res) => {
-  console.log("[updateInterestStatus] params:", req.params, "body:", req.body);
-
   try {
     const interestId = req.params.interestId || req.params.id;
     if (!interestId) return res.status(400).json({ message: "Missing interest id" });
@@ -108,7 +165,6 @@ exports.updateInterestStatus = async (req, res) => {
     let { status, preferredDate } = req.body;
     if (!status) return res.status(400).json({ message: "Invalid or missing status" });
 
-    // normalize common synonyms from frontend
     const norm = String(status).toLowerCase().trim();
     if (norm === "rejected" || norm === "declined") status = STATUS.DECLINED;
     else if (norm === "accepted") status = STATUS.ACCEPTED;
@@ -121,21 +177,12 @@ exports.updateInterestStatus = async (req, res) => {
     const interest = await Interest.findById(interestId).populate("propertyId");
     if (!interest) return res.status(404).json({ message: "Interest not found" });
 
-    // only the property owner can update
     if (String(interest.propertyId.ownerId) !== String(req.user.userId)) {
       return res.status(403).json({ message: "Forbidden" });
     }
 
-    // capture previous proposed date before changes
-    const prevDate = interest.preferredDate ? +interest.preferredDate : null;
-
-    // set status
     interest.status = status;
 
-    // handle preferredDate:
-    // - undefined => keep as is
-    // - null or "" => clear
-    // - string/Date => parse and set
     if (preferredDate === null || preferredDate === "") {
       interest.preferredDate = undefined;
     } else if (preferredDate !== undefined) {
@@ -144,48 +191,29 @@ exports.updateInterestStatus = async (req, res) => {
         return res.status(400).json({ message: "Invalid preferredDate" });
       }
       interest.preferredDate = d;
+      // remove from proposedDates if chosen
+      interest.proposedDates = interest.proposedDates.filter((pd) => +pd !== +d);
     }
 
     await interest.save();
 
-    // Determine if the proposed date changed while staying PENDING
-    const newDate = interest.preferredDate ? +interest.preferredDate : null;
-    const dateChanged = prevDate !== newDate;
-
-    // --- Notifications ---
     if (status === STATUS.ACCEPTED || status === STATUS.DECLINED) {
-      // match UI names: interest_accepted / interest_rejected
       const type = status === STATUS.ACCEPTED ? "interest_accepted" : "interest_rejected";
-
       let msg = `Your interest for "${interest.propertyId.title || "the property"}" was ${
         status === STATUS.ACCEPTED ? "accepted" : "rejected"
       }.`;
-
       if (status === STATUS.ACCEPTED && interest.preferredDate) {
-        msg += ` Proposed date: ${new Date(interest.preferredDate).toLocaleString()}`;
+        msg += ` Date: ${new Date(interest.preferredDate).toLocaleString()}`;
       }
-
       await sendNotification({
-        userId: interest.tenantId,   // tenant receives
-        senderId: req.user.userId,   // owner is sender
+        userId: interest.tenantId,
+        senderId: req.user.userId,
         type,
         referenceId: interest._id,
         message: msg,
       });
-    } else if (status === STATUS.PENDING && dateChanged) {
-      // owner proposed/changed/cleared a date while still pending -> inform tenant
-      await sendNotification({
-        userId: interest.tenantId,
-        senderId: req.user.userId,
-        type: "interest_proposed",
-        referenceId: interest._id,
-        message: interest.preferredDate
-          ? `Owner proposed date: ${new Date(interest.preferredDate).toLocaleString()}`
-          : `Owner cleared the proposed date.`,
-      });
     }
 
-    // return populated interest for immediate UI update
     const updated = await Interest.findById(interest._id)
       .populate("tenantId", "name email phone")
       .populate("propertyId", "title location ownerId");

--- a/backend/models/interests.js
+++ b/backend/models/interests.js
@@ -19,6 +19,12 @@ const interestSchema = new mongoose.Schema({
     default: "pending"
   },
 
+  // Dates proposed by the owner; tenant may later choose one
+  proposedDates: [{
+    type: Date,
+    default: undefined
+  }],
+
   preferredDate: { // 👈 από τον OWNER
     type: Date
   },

--- a/backend/models/notification.js
+++ b/backend/models/notification.js
@@ -10,6 +10,7 @@ const notificationSchema = new mongoose.Schema({
     type: String,
       enum: [
       "interest",
+      "interest_proposed",
       "interest_accepted",
       "interest_rejected",
       "message",

--- a/backend/routes/interests.js
+++ b/backend/routes/interests.js
@@ -13,6 +13,9 @@ router.get("/", verifyToken, interestController.getInterests);
 // Owner: Get single interest by ID (for modal)
 router.get("/:id", verifyToken, interestController.getInterestById);
 
+// Owner: Propose multiple dates
+router.post("/:id/proposals", verifyToken, interestController.proposeDates);
+
 // Owner: Update status + preferredDate
 // supports both styles:
 router.put("/:interestId", verifyToken, interestController.updateInterestStatus);

--- a/frontend/src/components/interestsModal.js
+++ b/frontend/src/components/interestsModal.js
@@ -1,4 +1,3 @@
-// src/components/InterestsModal.jsx
 import React, { useEffect, useState, useMemo } from 'react';
 import axios from 'axios';
 import { Modal, Button, Form } from 'react-bootstrap';
@@ -11,10 +10,11 @@ export default function InterestsModal({ interestId, onClose }) {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
   const [interest, setInterest] = useState(null);
 
-  // Local editable date (owner can propose or accept w/ date)
-  const [proposedDate, setProposedDate] = useState('');
+  const [ownerProposals, setOwnerProposals] = useState(['']);
+  const [selectedAcceptDate, setSelectedAcceptDate] = useState('');
 
   const isOwner = useMemo(() => {
     if (!user || !interest?.propertyId?.ownerId) return false;
@@ -24,77 +24,94 @@ export default function InterestsModal({ interestId, onClose }) {
     return user.id === ownerId;
   }, [user, interest]);
 
-  useEffect(() => {
-    let alive = true;
-    async function fetchInterest() {
-      setLoading(true);
-      setError('');
-      try {
-        const res = await axios.get(`/api/interests/${interestId}`, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
-        if (!alive) return;
-        setInterest(res.data);
-        // prefill proposedDate from server if exists
-        if (res.data?.preferredDate) {
-          const d = new Date(res.data.preferredDate);
-          // to 'YYYY-MM-DDTHH:mm' format for datetime-local
-          const iso = new Date(d.getTime() - d.getTimezoneOffset() * 60000)
-            .toISOString()
-            .slice(0, 16);
-          setProposedDate(iso);
-        }
-      } catch (e) {
-        if (!alive) return;
-        setError(e.response?.data?.message || 'Failed to load interest.');
-      } finally {
-        if (alive) setLoading(false);
-      }
-    }
-    if (interestId && token) fetchInterest();
-    return () => {
-      alive = false;
-    };
-  }, [interestId, token]);
-
-  const submitUpdate = async (payload) => {
-    setSaving(true);
+  const fetchInterest = async () => {
+    setLoading(true);
     setError('');
+    setSuccess('');
     try {
-      // Your routes expose: PUT /api/interests/:interestId
-      const res = await axios.put(`/api/interests/${interestId}`, payload, {
+      const res = await axios.get(`/api/interests/${interestId}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
-      setInterest(res.data?.interest || res.data); // controller returns {message, interest}
-      return true;
+      setInterest(res.data);
     } catch (e) {
-      setError(e.response?.data?.message || 'Update failed.');
-      return false;
+      setError(e.response?.data?.message || 'Failed to load interest.');
+    } finally {
+      setLoading(false);
+      setOwnerProposals(['']);
+      setSelectedAcceptDate('');
+    }
+  };
+
+  useEffect(() => {
+    if (interestId && token) fetchInterest();
+  }, [interestId, token]);
+
+  const updateProposal = (idx, value) => {
+    const next = [...ownerProposals];
+    next[idx] = value;
+    setOwnerProposals(next);
+  };
+
+  const addProposalInput = () => setOwnerProposals([...ownerProposals, '']);
+
+  const handlePropose = async () => {
+    setSaving(true);
+    setError('');
+    setSuccess('');
+    const dates = ownerProposals.filter(Boolean);
+    if (dates.length === 0) {
+      setError('Please add at least one date.');
+      setSaving(false);
+      return;
+    }
+    try {
+      await axios.post(`/api/interests/${interestId}/proposals`, { dates }, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setSuccess('Dates proposed.');
+      await fetchInterest();
+    } catch (e) {
+      setError(e.response?.data?.message || 'Proposal failed.');
     } finally {
       setSaving(false);
     }
   };
 
   const handleAccept = async () => {
-    const payload = { status: 'accepted' };
-    if (proposedDate) payload.preferredDate = proposedDate;
-    const ok = await submitUpdate(payload);
-    if (ok) onClose?.(); // close after success
+    setSaving(true);
+    setError('');
+    setSuccess('');
+    try {
+      await axios.put(`/api/interests/${interestId}`, {
+        status: 'accepted',
+        preferredDate: selectedAcceptDate || undefined,
+      }, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setSuccess('Interest accepted.');
+      await fetchInterest();
+    } catch (e) {
+      setError(e.response?.data?.message || 'Accept failed.');
+    } finally {
+      setSaving(false);
+    }
   };
 
   const handleReject = async () => {
-    const ok = await submitUpdate({ status: 'declined' });
-    if (ok) onClose?.();
-  };
-
-  const handlePropose = async () => {
-    if (!proposedDate) {
-      setError('Choose a date/time to propose.');
-      return;
+    setSaving(true);
+    setError('');
+    setSuccess('');
+    try {
+      await axios.put(`/api/interests/${interestId}`, { status: 'declined' }, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setSuccess('Interest rejected.');
+      await fetchInterest();
+    } catch (e) {
+      setError(e.response?.data?.message || 'Reject failed.');
+    } finally {
+      setSaving(false);
     }
-    // Keep status pending, only set preferredDate (backend should notify "interest_proposed")
-    const ok = await submitUpdate({ status: 'pending', preferredDate: proposedDate });
-    if (ok) onClose?.();
   };
 
   const formatDateTime = (iso) => {
@@ -111,7 +128,6 @@ export default function InterestsModal({ interestId, onClose }) {
       <Modal.Header closeButton>
         <Modal.Title>Interest details</Modal.Title>
       </Modal.Header>
-
       <Modal.Body>
         {loading ? (
           <p className="text-muted mb-0">Loading…</p>
@@ -121,6 +137,8 @@ export default function InterestsModal({ interestId, onClose }) {
           <p className="text-muted mb-0">Not found.</p>
         ) : (
           <>
+            {success && <div className="alert alert-success">{success}</div>}
+
             <div className="mb-3">
               <div><strong>Property:</strong> {interest.propertyId?.title || '—'}</div>
               <div><strong>Location:</strong> {interest.propertyId?.location || '—'}</div>
@@ -137,67 +155,83 @@ export default function InterestsModal({ interestId, onClose }) {
               <div className="mt-1">{interest.message || <span className="text-muted">No message</span>}</div>
             </div>
 
-            <div className="row g-2 mb-3">
-              <div className="col-6">
-                <div><strong>Status:</strong> <span className="text-capitalize">{interest.status}</span></div>
-              </div>
-              <div className="col-6">
-                <div><strong>Submitted:</strong> {formatDateTime(interest.submittedAt)}</div>
-              </div>
-              <div className="col-12">
-                <div><strong>Proposed date:</strong> {formatDateTime(interest.preferredDate)}</div>
-              </div>
+            <div className="mb-3">
+              <div><strong>Status:</strong> <span className="text-capitalize">{interest.status}</span></div>
+              <div><strong>Submitted:</strong> {formatDateTime(interest.submittedAt)}</div>
+            </div>
+
+            <div className="mb-3">
+              <strong>Proposed dates:</strong>
+              <ul className="mt-2">
+                {(interest.proposedDates || []).length === 0 ? (
+                  <li className="text-muted">None</li>
+                ) : (
+                  interest.proposedDates.map((d) => (
+                    <li key={d}>{formatDateTime(d)}</li>
+                  ))
+                )}
+              </ul>
             </div>
 
             {isOwner && (
               <>
                 <hr />
+                <div className="mb-3">
+                  <strong>Propose new dates</strong>
+                  {ownerProposals.map((val, idx) => (
+                    <Form.Control
+                      key={idx}
+                      type="datetime-local"
+                      className="mt-2"
+                      value={val}
+                      onChange={(e) => updateProposal(idx, e.target.value)}
+                    />
+                  ))}
+                  <Button variant="link" className="p-0 mt-2" onClick={addProposalInput}>
+                    + Add another
+                  </Button>
+                  <Button
+                    variant="outline-primary"
+                    className="mt-3"
+                    onClick={handlePropose}
+                    disabled={saving}
+                  >
+                    Propose dates
+                  </Button>
+                </div>
+
                 <Form.Group className="mb-3">
-                  <Form.Label>Propose / confirm date & time</Form.Label>
-                  <Form.Control
-                    type="datetime-local"
-                    value={proposedDate}
-                    onChange={(e) => setProposedDate(e.target.value)}
-                  />
-                  <Form.Text className="text-muted">
-                    You can set a proposed date alone (keeps status pending) or accept and include a date.
-                  </Form.Text>
+                  <Form.Label>Choose a date to accept (optional)</Form.Label>
+                  <Form.Select
+                    value={selectedAcceptDate}
+                    onChange={(e) => setSelectedAcceptDate(e.target.value)}
+                  >
+                    <option value="">-- none --</option>
+                    {interest.proposedDates?.map((d) => {
+                      const iso = new Date(d).toISOString().slice(0,16);
+                      return (
+                        <option key={d} value={iso}>
+                          {formatDateTime(d)}
+                        </option>
+                      );
+                    })}
+                  </Form.Select>
                 </Form.Group>
               </>
             )}
           </>
         )}
       </Modal.Body>
-
       <Modal.Footer className="d-flex justify-content-between">
         <Button variant="outline-secondary" onClick={onClose} disabled={saving}>
           Close
         </Button>
-
         {isOwner && !loading && interest && (
           <div className="d-flex gap-2">
-            <Button
-              variant="outline-danger"
-              onClick={handleReject}
-              disabled={saving}
-              title="Reject interest"
-            >
+            <Button variant="outline-danger" onClick={handleReject} disabled={saving}>
               Reject
             </Button>
-            <Button
-              variant="outline-primary"
-              onClick={handlePropose}
-              disabled={saving}
-              title="Propose date (keeps pending)"
-            >
-              Propose date
-            </Button>
-            <Button
-              variant="primary"
-              onClick={handleAccept}
-              disabled={saving}
-              title="Accept interest"
-            >
+            <Button variant="primary" onClick={handleAccept} disabled={saving}>
               Accept
             </Button>
           </div>


### PR DESCRIPTION
## Summary
- allow owners to propose multiple meeting dates on interests
- send notifications for proposed, accepted or rejected interests
- add owner UI to manage proposals and acceptance

## Testing
- `npm test` (backend) (fails: Error: no test specified)
- `npm test --silent` (frontend) (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_689cf515094883229b5cd5020a7cdc5d