### PR TITLE
refactor: use shared api client

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,12 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: '/api'
+});
+
+const token = localStorage.getItem('token');
+if (token) {
+  api.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+}
+
+export default api;

--- a/frontend/src/components/AppointmentModal.js
+++ b/frontend/src/components/AppointmentModal.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import axios from "axios";
+import api from "../api";
 import { Modal, Button } from "react-bootstrap";
 
 function AppointmentModal({ appointmentId, onClose }) {
@@ -20,7 +20,7 @@ function AppointmentModal({ appointmentId, onClose }) {
       setFetching(true);
       setError("");
       try {
-        const res = await axios.get(`/api/appointments/${appointmentId}`, { headers });
+        const res = await api.get(`/appointments/${appointmentId}`, { headers });
         if (!alive) return;
         setAppointment(res.data);
       } catch (err) {
@@ -41,8 +41,8 @@ function AppointmentModal({ appointmentId, onClose }) {
     setError("");
     try {
       // ✅ σωστό path + method σύμφωνα με το backend
-      await axios.put(
-        `/api/appointments/confirm/${appointmentId}`,
+      await api.put(
+        `/appointments/confirm/${appointmentId}`,
         { selectedSlot },     // ✅ στέλνουμε το original string
         { headers }
       );

--- a/frontend/src/components/NotificationDropdown.js
+++ b/frontend/src/components/NotificationDropdown.js
@@ -1,3 +1,4 @@
+import api from '../api';
 {/* Notifications Dropdown */}
 <div ref={dropdownRef} className="position-relative">
   <button
@@ -31,7 +32,7 @@
                   try {
                     await Promise.all(
                       unread.map(n =>
-                        axios.patch(`/api/notifications/${n._id}/read`, {}, {
+                        api.patch(`/notifications/${n._id}/read`, {}, {
                           headers: { Authorization: `Bearer ${token}` }
                         })
                       )
@@ -77,7 +78,7 @@
                     setNotifications(prev => prev.map(n => n._id === note._id ? { ...n, read: true } : n));
                     setUnreadCount(c => Math.max(0, c - 1));
                     try {
-                      await axios.patch(`/api/notifications/${note._id}/read`, {}, {
+                      await api.patch(`/notifications/${note._id}/read`, {}, {
                         headers: { Authorization: `Bearer ${token}` }
                       });
                     } catch (e) {
@@ -157,3 +158,5 @@
     </div>
   )}
 </div>
+import api from '../api';
+{/* Notifications Dropdown */}

--- a/frontend/src/components/ProposeAppointmentModal.js
+++ b/frontend/src/components/ProposeAppointmentModal.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Modal, Button, Form } from "react-bootstrap";
-import axios from "axios";
+import api from "../api";
 
 function ProposeAppointmentModal({ show, onClose, tenantId, propertyId }) {
   const [slots, setSlots] = useState([""]); // ξεκινάμε με 1 πεδίο
@@ -63,8 +63,8 @@ function ProposeAppointmentModal({ show, onClose, tenantId, propertyId }) {
     }
 
     try {
-      await axios.post(
-        "/api/appointments/propose",
+      await api.post(
+        "/appointments/propose",
         { tenantId, propertyId, availableSlots: cleaned },
         { headers }
       );

--- a/frontend/src/components/interestsModal.js
+++ b/frontend/src/components/interestsModal.js
@@ -1,6 +1,6 @@
 // src/components/InterestsModal.jsx
 import React, { useEffect, useState, useMemo, useCallback } from 'react';
-import axios from 'axios';
+import api from '../api';
 import ProposeAppointmentModal from './ProposeAppointmentModal';
 import { useAuth } from '../context/AuthContext';
 import { Modal, Form, Button } from 'react-bootstrap';
@@ -49,7 +49,7 @@ function InterestsModal({ interestId, onClose }) {
     setLoading(true);
     setError('');
     try {
-      const res = await axios.get(`/api/interests/${interestId}`, { headers });
+      const res = await api.get(`/interests/${interestId}`, { headers });
       setInterest(res.data);
 
       if (res.data?.preferredDate) {
@@ -76,7 +76,7 @@ function InterestsModal({ interestId, onClose }) {
     setSaving(true);
     setError('');
     try {
-      const res = await axios.put(`/api/interests/${interestId}`, payload, { headers });
+      const res = await api.put(`/interests/${interestId}`, payload, { headers });
       setInterest(res.data?.interest || res.data);
       return true;
     } catch (e) {

--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -1,6 +1,6 @@
 // src/context/AuthContext.jsx
 import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
-import axios from "axios";
+import api from "../api";
 
 const AuthContext = createContext(null);
 export const useAuth = () => useContext(AuthContext);
@@ -13,10 +13,10 @@ export const AuthProvider = ({ children }) => {
   const [token, setToken] = useState(() => localStorage.getItem("token") || null);
   const [authReady, setAuthReady] = useState(false);
 
-  // Keep axios Authorization header in sync with token
+  // Keep API Authorization header in sync with token
   useEffect(() => {
-    if (token) axios.defaults.headers.common.Authorization = `Bearer ${token}`;
-    else delete axios.defaults.headers.common.Authorization;
+    if (token) api.defaults.headers.common.Authorization = `Bearer ${token}`;
+    else delete api.defaults.headers.common.Authorization;
   }, [token]);
 
   // Verify token / refresh user once on mount
@@ -25,7 +25,7 @@ export const AuthProvider = ({ children }) => {
     const bootstrap = async () => {
       if (!token) { setAuthReady(true); return; }
       try {
-        const res = await axios.get("/api/user/profile");
+        const res = await api.get("/user/profile");
         const data = res.data?.user || res.data; // handle either shape
         if (!cancelled && data) {
           setUser(data);
@@ -47,14 +47,14 @@ export const AuthProvider = ({ children }) => {
 
   // Optional helpers
   const login = async (email, password) => {
-    const res = await axios.post("/api/auth/login", { email, password });
+    const res = await api.post("/auth/login", { email, password });
     const tk = res.data.token;
     const usr = res.data.user;
     setToken(tk);
     setUser(usr);
     localStorage.setItem("token", tk);
     localStorage.setItem("user", JSON.stringify(usr));
-    axios.defaults.headers.common.Authorization = `Bearer ${tk}`;
+    api.defaults.headers.common.Authorization = `Bearer ${tk}`;
   };
 
   const logout = () => {
@@ -62,7 +62,7 @@ export const AuthProvider = ({ children }) => {
     setToken(null);
     localStorage.removeItem("token");
     localStorage.removeItem("user");
-    delete axios.defaults.headers.common.Authorization;
+    delete api.defaults.headers.common.Authorization;
   };
 
   const value = useMemo(() => ({

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -5,15 +5,14 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
-import axios from "axios";
+import api from "./api";
 
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 
-axios.defaults.baseURL = "http://localhost:5000"; // match your backend
 const bootToken = localStorage.getItem("token");
 if (bootToken) {
-  axios.defaults.headers.common["Authorization"] = `Bearer ${bootToken}`;
+  api.defaults.headers.common["Authorization"] = `Bearer ${bootToken}`;
 }
 root.render(
   <React.StrictMode>

--- a/frontend/src/pages/AddProperty.js
+++ b/frontend/src/pages/AddProperty.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import axios from "axios";
+import api from "../api";
 import { useAuth } from "../context/AuthContext";
 import { useNavigate } from "react-router-dom";
 import {
@@ -135,7 +135,7 @@ export default function AddProperty() {
 
     try {
       const token = localStorage.getItem("token");
-      await axios.post("/api/properties", data, {
+      await api.post("/properties", data, {
         headers: {
           Authorization: `Bearer ${token}`,
           "Content-Type": "multipart/form-data",

--- a/frontend/src/pages/Appointments.js
+++ b/frontend/src/pages/Appointments.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import axios from 'axios';
+import api from '../api';
 import { useAuth } from '../context/AuthContext';
 import { Link, useNavigate } from 'react-router-dom';
 import AppointmentModal from '../components/AppointmentModal'; // ✅ σωστό import (front-end modal)
@@ -23,11 +23,11 @@ function Appointments() {
     const fetchAppointments = async () => {
       try {
         const endpoint =
-          user?.role === 'owner' ? '/api/appointments/owner' : '/api/appointments/tenant';
+          user?.role === 'owner' ? '/appointments/owner' : '/appointments/tenant';
 
         const headers = token ? { Authorization: `Bearer ${token}` } : undefined; // ✅ μόνο αν υπάρχει token
 
-        const res = await axios.get(endpoint, { headers });
+        const res = await api.get(endpoint, { headers });
         setAppointments(res.data || []);
       } catch (err) {
         console.error('Error fetching appointments:', err);
@@ -119,8 +119,8 @@ function Appointments() {
             // προαιρετικά κάνε refresh τη λίστα μετά από confirm
             setSelectedAppointmentId(null);
             setLoading(true);
-            axios
-              .get(user?.role === 'owner' ? '/api/appointments/owner' : '/api/appointments/tenant', {
+            api
+              .get(user?.role === 'owner' ? '/appointments/owner' : '/appointments/tenant', {
                 headers: token ? { Authorization: `Bearer ${token}` } : undefined,
               })
               .then((res) => setAppointments(res.data || []))

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { useAuth } from '../context/AuthContext';
 import { useNavigate, Link } from 'react-router-dom';
-import axios from 'axios';
+import api from '../api';
 import GoogleMapView from '../components/GoogleMapView';
 import filterIcon from '../assets/filters.jpg';
 import InterestsModal from '../components/InterestsModal';
@@ -87,13 +87,13 @@ function Dashboard() {
   const handleFavorite = async (propertyId) => {
     try {
       if (favorites.includes(propertyId)) {
-        await axios.delete(`/api/favorites/${propertyId}`, {
+        await api.delete(`/favorites/${propertyId}`, {
           headers: { Authorization: `Bearer ${token}` },
         });
         setFavorites((prev) => prev.filter((id) => id !== propertyId));
       } else {
-        await axios.post(
-          '/api/favorites',
+        await api.post(
+          '/favorites',
           { propertyId },
           {
             headers: {
@@ -135,7 +135,7 @@ function Dashboard() {
         page: overrides.page ?? 1,
         limit: overrides.limit ?? 24,
       };
-      const res = await axios.get('/api/properties', { params });
+      const res = await api.get('/properties', { params });
 
       // normalize array/object response
       const items = Array.isArray(res.data) ? res.data : (res.data?.items || []);
@@ -153,7 +153,7 @@ function Dashboard() {
   // ---- notifications ----
   const fetchNotifications = useCallback(async () => {
     try {
-      const res = await axios.get('/api/notifications', {
+      const res = await api.get('/notifications', {
         headers: { Authorization: `Bearer ${token}` },
       });
       const list = Array.isArray(res.data) ? res.data : [];
@@ -184,8 +184,8 @@ function Dashboard() {
 
     fetchProperties();
 
-    axios
-      .get('/api/favorites', { headers: { Authorization: `Bearer ${token}` } })
+    api
+      .get('/favorites', { headers: { Authorization: `Bearer ${token}` } })
       .then((res) => {
         const arr = Array.isArray(res.data) ? res.data : [];
         // map to property ids safely
@@ -197,9 +197,8 @@ function Dashboard() {
     fetchNotifications();
 
     const endpoint =
-      user.role === 'owner' ? '/api/appointments/owner' : '/api/appointments/tenant';
-
-    axios
+      user.role === 'owner' ? '/appointments/owner' : '/appointments/tenant';
+    api
       .get(endpoint, { headers: { Authorization: `Bearer ${token}` } })
       .then((res) => {
         const appts = Array.isArray(res.data) ? res.data : [];
@@ -268,8 +267,8 @@ function Dashboard() {
         try {
           await Promise.all(
             unread.map((n) =>
-              axios.patch(
-                `/api/notifications/${n._id}/read`,
+              api.patch(
+                `/notifications/${n._id}/read`,
                 {},
                 { headers: { Authorization: `Bearer ${token}` } }
               )
@@ -425,7 +424,7 @@ function Dashboard() {
                             try {
                               await Promise.all(
                                 unread.map(n =>
-                                  axios.patch(`/api/notifications/${n._id}/read`, {}, {
+                                  api.patch(`/notifications/${n._id}/read`, {}, {
                                     headers: { Authorization: `Bearer ${token}` }
                                   })
                                 )
@@ -471,7 +470,7 @@ function Dashboard() {
                               setNotifications(prev => prev.map(n => n._id === note._id ? { ...n, read: true } : n));
                               setUnreadCount(c => Math.max(0, c - 1));
                               try {
-                                await axios.patch(`/api/notifications/${note._id}/read`, {}, {
+                                await api.patch(`/notifications/${note._id}/read`, {}, {
                                   headers: { Authorization: `Bearer ${token}` }
                                 });
                               } catch (e) {

--- a/frontend/src/pages/EditProperty.js
+++ b/frontend/src/pages/EditProperty.js
@@ -1,7 +1,7 @@
 // src/pages/EditProperty.jsx
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import axios from 'axios';
+import api from '../api';
 import {
   GoogleMap,
   Marker,
@@ -92,7 +92,7 @@ function EditProperty() {
   useEffect(() => {
     const fetchProperty = async () => {
       try {
-        const res = await axios.get(`/api/properties/${propertyId}`);
+        const res = await api.get(`/properties/${propertyId}`);
         const p = res.data;
 
         setFormData({
@@ -191,7 +191,7 @@ function EditProperty() {
     newImages.forEach((img) => submissionData.append('images', img));
 
     try {
-      await axios.put(`/api/properties/${propertyId}`, submissionData, {
+      await api.put(`/properties/${propertyId}`, submissionData, {
         headers: {
           Authorization: `Bearer ${token}`,
           'Content-Type': 'multipart/form-data'

--- a/frontend/src/pages/Home.js
+++ b/frontend/src/pages/Home.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import axios from "axios";
+import api from "../api";
 import GoogleMapView from "../components/GoogleMapView";
 
 function Home() {
@@ -27,7 +27,7 @@ function Home() {
   useEffect(() => {
     const fetchFeatured = async () => {
       try {
-        const res = await axios.get("/api/properties", {
+        const res = await api.get("/properties", {
           params: {
             sort: "relevance",
             q: "", // κενό query στη home

--- a/frontend/src/pages/MyProperties.js
+++ b/frontend/src/pages/MyProperties.js
@@ -2,7 +2,7 @@
 import React, { useEffect, useState } from 'react';
 import { useAuth } from '../context/AuthContext';
 import { Link, useNavigate } from 'react-router-dom';
-import axios from 'axios';
+import api from '../api';
 import { Button, Table, Badge, Spinner } from 'react-bootstrap';
 
 export default function MyProperties() {
@@ -24,7 +24,7 @@ export default function MyProperties() {
       try {
         const token = localStorage.getItem('token');
         // Προτιμώ backend που επιστρέφει ήδη counts:
-        const res = await axios.get('/api/properties/mine?includeStats=1', {
+        const res = await api.get('/properties/mine?includeStats=1', {
           headers: { Authorization: `Bearer ${token}` },
         });
         setItems(res.data || []);
@@ -41,7 +41,7 @@ export default function MyProperties() {
     if (!window.confirm('Delete this property?')) return;
     try {
       const token = localStorage.getItem('token');
-      await axios.delete(`/api/properties/${id}`, {
+      await api.delete(`/properties/${id}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       setItems(items.filter((p) => p._id !== id));

--- a/frontend/src/pages/Notifications.js
+++ b/frontend/src/pages/Notifications.js
@@ -1,6 +1,6 @@
 // src/pages/NotificationsPage.jsx
 import React, { useEffect, useState, useCallback } from 'react';
-import axios from 'axios';
+import api from '../api';
 import { Link, useNavigate } from 'react-router-dom';
 import AppointmentModal from '../components/AppointmentModal';
 import InterestsModal from '../components/InterestsModal';
@@ -23,7 +23,7 @@ export default function NotificationsPage() {
   const fetchAll = useCallback(async () => {
     setLoading(true);
     try {
-      const res = await axios.get('/api/notifications', {
+      const res = await api.get('/notifications', {
         headers: { Authorization: `Bearer ${token}` },
       });
       setItems(res.data || []);
@@ -43,7 +43,7 @@ export default function NotificationsPage() {
       const unread = items.filter(n => !n.read);
       await Promise.all(
         unread.map(n =>
-          axios.patch(`/api/notifications/${n._id}/read`, {}, {
+          api.patch(`/notifications/${n._id}/read`, {}, {
             headers: { Authorization: `Bearer ${token}` }
           })
         )
@@ -56,7 +56,7 @@ export default function NotificationsPage() {
 
   const markSingleRead = async (noteId) => {
     try {
-      await axios.patch(`/api/notifications/${noteId}/read`, {}, {
+      await api.patch(`/notifications/${noteId}/read`, {}, {
         headers: { Authorization: `Bearer ${token}` },
       });
       setItems(prev => prev.map(n => n._id === noteId ? { ...n, read: true } : n));

--- a/frontend/src/pages/Properties.js
+++ b/frontend/src/pages/Properties.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import axios from 'axios';
+import api from '../api';
 
 function Properties() {
   const [properties, setProperties] = useState([]);
@@ -14,7 +14,7 @@ function Properties() {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const res = await axios.get('http://localhost:5000/api/properties');
+        const res = await api.get('/properties');
         setProperties(res.data);
       } catch (err) {
         console.error('Error fetching properties', err);

--- a/frontend/src/pages/PropertyDetails.js
+++ b/frontend/src/pages/PropertyDetails.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
-import axios from 'axios';
+import api from '../api';
 import { Modal, Button, Form } from 'react-bootstrap';
 import GoogleMapView from '../components/GoogleMapView';
 
@@ -41,7 +41,7 @@ function PropertyDetails() {
 
     const fetchProperty = async () => {
       try {
-        const res = await axios.get(`/api/properties/${propertyId}`);
+        const res = await api.get(`/properties/${propertyId}`);
         if (mounted) {
           setProperty(res.data);
           setCurrentImageIndex(0);
@@ -53,7 +53,7 @@ function PropertyDetails() {
 
     const checkFavorite = async () => {
       try {
-        const res = await axios.get('/api/favorites', {
+        const res = await api.get('/favorites', {
           headers: { Authorization: `Bearer ${token}` },
         });
         const fav = res.data.find((f) => f.propertyId?._id === propertyId);
@@ -74,14 +74,14 @@ function PropertyDetails() {
   const handleFavorite = async () => {
     try {
       if (!isFavorite) {
-        await axios.post(
-          '/api/favorites',
+        await api.post(
+          '/favorites',
           { propertyId },
           { headers: { Authorization: `Bearer ${token}` } }
         );
         setIsFavorite(true);
       } else {
-        await axios.delete(`/api/favorites/${propertyId}`, {
+        await api.delete(`/favorites/${propertyId}`, {
           headers: { Authorization: `Bearer ${token}` },
         });
         setIsFavorite(false);
@@ -94,8 +94,8 @@ function PropertyDetails() {
   const handleInterestSubmit = async (e) => {
     e.preventDefault();
     try {
-      await axios.post(
-        '/api/interests',
+      await api.post(
+        '/interests',
         { propertyId, message: interestMessage },
         { headers: { Authorization: `Bearer ${token}` } }
       );
@@ -110,7 +110,7 @@ function PropertyDetails() {
   const handleDelete = async () => {
     if (!window.confirm('Are you sure you want to delete this property?')) return;
     try {
-      await axios.delete(`/api/properties/${propertyId}`, {
+      await api.delete(`/properties/${propertyId}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       navigate('/dashboard');

--- a/frontend/src/pages/Register.js
+++ b/frontend/src/pages/Register.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import axios from 'axios';
+import api from '../api';
 import { useNavigate, Link } from 'react-router-dom';
 
 function Register() {
@@ -32,7 +32,7 @@ function Register() {
   const handleRegister = async (e) => {
     e.preventDefault();
     try {
-      await axios.post('/api/auth/register', formData);
+      await api.post('/auth/register', formData);
       setMessage('Registration successful! Redirecting to login...');
       setTimeout(() => navigate('/login'), 1500);
     } catch (err) {

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -1,14 +1,14 @@
-import axios from 'axios';
+import api from '../api';
 
-const API = 'http://localhost:5000/api/auth';
+const API = '/auth';
 export const loginUser  = async(credentials) => {
-const res = await axios.post(`${API}/login`, credentials);
+const res = await api.post(`${API}/login`, credentials);
 
 return res.data;
 };
 
 export const registerUser = async(userData) => {
-    const res = await axios.post(`${API}/register`, userData);
+    const res = await api.post(`${API}/register`, userData);
     return res.data;
 };
 

--- a/frontend/src/services/favoritesService.js
+++ b/frontend/src/services/favoritesService.js
@@ -1,9 +1,9 @@
-import axios from 'axios';
+import api from '../api';
 
-const API_URL = 'http://localhost:5000/api/favorites';
+const API_URL = '/favorites';
 
 export const getFavorites = async (token) => {
-    const res = await axios.get(`${API_URL}`, {
+    const res = await api.get(`${API_URL}`, {
         headers: {
             Authorization: `Bearer ${token}`
         }
@@ -12,7 +12,7 @@ export const getFavorites = async (token) => {
 };
 
 export const addFavorite = async (propertyId, token) => {
-    const res = await axios.post(`${API_URL}`, { propertyId }, {
+    const res = await api.post(`${API_URL}`, { propertyId }, {
         headers: {
             Authorization: `Bearer ${token}`
         }
@@ -21,7 +21,7 @@ export const addFavorite = async (propertyId, token) => {
 };
 
 export const removeFavorite = async (propertyId, token) => {
-    const res = await axios.delete(`${API_URL}/${propertyId}`, {
+    const res = await api.delete(`${API_URL}/${propertyId}`, {
         headers: {
             Authorization: `Bearer ${token}`
         }

--- a/frontend/src/services/messagesService.js
+++ b/frontend/src/services/messagesService.js
@@ -1,9 +1,9 @@
-import axios from 'axios';
+import api from '../api';
 
-const API_URL = 'http://localhost:5000/api/messages';
+const API_URL = '/messages';
 
 export const sendMessage = async (receiverId,content, token) => {
-    const res = await axios.post(`${API_URL}`, { receiverId, content }, {
+    const res = await api.post(`${API_URL}`, { receiverId, content }, {
         headers: {
             Authorization: `Bearer ${token}`
         }
@@ -11,7 +11,7 @@ export const sendMessage = async (receiverId,content, token) => {
     return res.data;
 };
 export const getMessages = async (token) => {
-    const res = await axios.get(`${API_URL}`, {
+    const res = await api.get(`${API_URL}`, {
         headers: {
             Authorization: `Bearer ${token}`
         }

--- a/frontend/src/services/userService.js
+++ b/frontend/src/services/userService.js
@@ -1,10 +1,10 @@
-import axios from 'axios';
+import api from '../api';
 
-const API_BASE  = 'http://localhost:5000/api/user';
+const API_BASE = '/user';
 
 export const getUserProfile = async()=>{
     const token = localStorage.getItem('token');
-    const res = await axios.get(`${API_BASE}/profile`, {
+    const res = await api.get(`${API_BASE}/profile`, {
         headers: {
             Authorization: `Bearer ${token}`
         }
@@ -14,7 +14,7 @@ export const getUserProfile = async()=>{
 
 export const updateUserProfile = async(updatedData)=>{
     const token = localStorage.getItem('token');
-    const res = await axios.put(`${API_BASE}/profile`, updatedData,{
+    const res = await api.put(`${API_BASE}/profile`, updatedData,{
         headers: {
             Authorization: `Bearer ${token}`
         }


### PR DESCRIPTION
## Summary
- add centralized axios instance at `src/api.js`
- replace direct axios usage with shared API client across services, pages, and components

## Testing
- `cd frontend && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689f6cbecf388322bb06642d47de81bc