### PR TITLE
Add matching pages for clients and properties

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -8,6 +8,8 @@ import ProtectedRoute from './components/ProtectedRoute';
 import Profile from './pages/Profile';
 import Favorites from './pages/Favorites';
 import Messages from './pages/Messages';
+import MatchClients from './pages/MatchClients';
+import MatchProperties from './pages/MatchProperties';
 import Notifications from './pages/Notifications';
 import EditProfile from './pages/EditProfile';
 import AddProperty from './pages/AddProperty';
@@ -73,6 +75,24 @@ function App() {
           element={
             <ProtectedRoute>
               <Messages />
+            </ProtectedRoute>
+          }
+        />
+
+        <Route
+          path="/match/clients"
+          element={
+            <ProtectedRoute>
+              <MatchClients />
+            </ProtectedRoute>
+          }
+        />
+
+        <Route
+          path="/match/properties"
+          element={
+            <ProtectedRoute>
+              <MatchProperties />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -4,16 +4,14 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 
 function Layout({ children }) {
-  const { user, setUser } = useAuth();
+  const { user, logout } = useAuth();
   const navigate = useNavigate();
 
   const [showProfileMenu, setShowProfileMenu] = useState(false);
   const profileMenuRef = useRef(null);
 
   const handleLogout = () => {
-    localStorage.removeItem('token');
-    localStorage.removeItem('user');
-    setUser(null);
+    logout();
     navigate('/');
   };
 

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -50,7 +50,7 @@ function normalizeUploadPath(src) {
 }
 
 function Dashboard() {
-  const { user, setUser } = useAuth();
+  const { user, logout } = useAuth();
   const navigate = useNavigate();
 
   /* ---------- state ---------- */
@@ -123,8 +123,7 @@ const pageGradient = useMemo(() => ({
 
   /* ---------- actions ---------- */
   const handleLogout = () => {
-    localStorage.removeItem('token');
-    setUser(null);
+    logout();
     navigate('/');
   };
 

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -728,9 +728,37 @@ const pageGradient = useMemo(() => ({
           <div className="col-lg-7">
               <div className="d-flex align-items-center gap-3 mb-3 flex-wrap">
               <h4 className="fw-bold mb-0">Featured Properties</h4>
-               {user?.role === 'owner' && (
+              {user?.role === 'owner' && (
+                <>
+                  <Link
+                    to="/add-property"
+                    className="btn d-flex align-items-center gap-2 px-3 py-2 rounded-pill shadow-sm"
+                    style={{
+                      background: 'linear-gradient(135deg,#006400,#90ee90)',
+                      color: '#fff',
+                      fontWeight: 600,
+                      border: 'none',
+                    }}
+                  >
+                    Add Property
+                  </Link>
+                  <Link
+                    to="/match/clients"
+                    className="btn d-flex align-items-center gap-2 px-3 py-2 rounded-pill shadow-sm"
+                    style={{
+                      background: 'linear-gradient(135deg,#006400,#90ee90)',
+                      color: '#fff',
+                      fontWeight: 600,
+                      border: 'none',
+                    }}
+                  >
+                    Suggested Tenants
+                  </Link>
+                </>
+              )}
+              {user?.role === 'client' && (
                 <Link
-                  to="/add-property"
+                  to="/match/properties"
                   className="btn d-flex align-items-center gap-2 px-3 py-2 rounded-pill shadow-sm"
                   style={{
                     background: 'linear-gradient(135deg,#006400,#90ee90)',
@@ -739,7 +767,7 @@ const pageGradient = useMemo(() => ({
                     border: 'none',
                   }}
                 >
-                  Add Property
+                  Suggested Homes
                 </Link>
               )}
               {/* Toggle: All / Sale / Rent */}

--- a/frontend/src/pages/MatchClients.js
+++ b/frontend/src/pages/MatchClients.js
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import api from '../api';
+
+function MatchClients() {
+  const [clients, setClients] = useState([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchClients = async () => {
+      try {
+        const token = localStorage.getItem('token');
+        const res = await api.get('/match/clients', {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        const data = Array.isArray(res.data) ? res.data : [];
+        setClients(data);
+      } catch (err) {
+        console.error('Failed to fetch client matches', err);
+        setClients([]);
+      }
+    };
+
+    fetchClients();
+  }, []);
+
+  return (
+    <div className="container mt-4">
+      <h3>Suggested Tenants</h3>
+      <div className="row">
+        {clients.map((c) => (
+          <div className="col-md-4 mb-4" key={c._id}>
+            <div className="card h-100">
+              <div className="card-body d-flex flex-column">
+                <h5 className="card-title">{c.name}</h5>
+                {c.occupation && <p className="card-text">Occupation: {c.occupation}</p>}
+                {(c.incomeMin || c.incomeMax) && (
+                  <p className="card-text">
+                    Income: €{c.incomeMin ?? '?'} - €{c.incomeMax ?? '?'}
+                  </p>
+                )}
+                {c.familyStatus && (
+                  <p className="card-text">Family: {c.familyStatus}</p>
+                )}
+                <div className="mb-3">
+                  {c.hasPets && <span className="badge bg-info text-dark me-2">Pets</span>}
+                  {c.smoker && <span className="badge bg-warning text-dark">Smoker</span>}
+                </div>
+                <button
+                  className="mt-auto btn btn-primary"
+                  onClick={() => navigate('/messages')}
+                >
+                  Message
+                </button>
+              </div>
+            </div>
+          </div>
+        ))}
+        {clients.length === 0 && (
+          <p className="text-muted">No matches found.</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default MatchClients;

--- a/frontend/src/pages/MatchProperties.js
+++ b/frontend/src/pages/MatchProperties.js
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+import api from '../api';
+import PropertyCard from '../components/propertyCard';
+
+function MatchProperties() {
+  const [properties, setProperties] = useState([]);
+
+  useEffect(() => {
+    const fetchProperties = async () => {
+      try {
+        const token = localStorage.getItem('token');
+        const res = await api.get('/match/properties', {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        const data = Array.isArray(res.data) ? res.data : [];
+        setProperties(data);
+      } catch (err) {
+        console.error('Failed to fetch property matches', err);
+        setProperties([]);
+      }
+    };
+
+    fetchProperties();
+  }, []);
+
+  const imgUrl = (src) =>
+    src ? (src.startsWith('http') ? src : `http://localhost:5000${src}`) : '';
+
+  return (
+    <div className="container mt-4">
+      <h3>Suggested Homes</h3>
+      <div className="row g-3">
+        {properties.map((prop) => (
+          <div className="col-md-4" key={prop._id}>
+            <PropertyCard prop={prop} imgUrl={imgUrl} />
+          </div>
+        ))}
+        {properties.length === 0 && (
+          <p className="text-muted">No matches found.</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default MatchProperties;


### PR DESCRIPTION
## Summary
- implement `MatchClients` to fetch client suggestions and provide messaging shortcut
- add `MatchProperties` to display recommended properties via `PropertyCard`
- extend Dashboard and router with buttons and routes for new match pages

## Testing
- `npm test -- --watchAll=false` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b0468fb06483229cf15c764a2c120a