### PR TITLE
Add importance handling to property requirements

### DIFF
--- a/backend/__tests__/matching.test.js
+++ b/backend/__tests__/matching.test.js
@@ -2,43 +2,61 @@
 const { computeMatchScore } = require("../utils/matching");
 
 describe("computeMatchScore", () => {
-  test("matches when client budget & sqm meet property and ≥50% score", () => {
-    const client = { maxPrice: 900, minSqm: 70, familyStatus: "Single", furnished: true };
-    const ownerReqs = { furnished: true, familyStatus: "Single" };
-    const prop = { rent: 800, squareMeters: 80, bedrooms: 2, bathrooms: 1 };
+  test("hard requirement mismatch triggers hard fail", () => {
+    const client = { maxPrice: 1000, minSqm: 60, pets: true };
+    const ownerReqs = [
+      { name: "pets", value: false, importance: "high" },
+      { name: "furnished", value: true, importance: "low" },
+    ];
+    const prop = { rent: 900, squareMeters: 80 };
 
     const r = computeMatchScore(client, ownerReqs, prop);
-    expect(r.hardFails).toBeUndefined();
-    expect(r.score).toBeGreaterThanOrEqual(0.5);
+    expect(r.score).toBe(0);
+    expect(r.hardFails).toContain("pets");
   });
 
-  test("hard-fail on budget (should exclude: score = 0)", () => {
+  test("properties pass when high requirements match and ≥50% of lows", () => {
+    const client = {
+      maxPrice: 900,
+      minSqm: 70,
+      familyStatus: "Single",
+      furnished: true,
+      parking: false,
+      elevator: true,
+    };
+    const ownerReqs = [
+      { name: "familyStatus", value: "single", importance: "high" },
+      { name: "furnished", value: true, importance: "low" },
+      { name: "parking", value: true, importance: "low" },
+      { name: "hasElevator", value: true, importance: "low" },
+    ];
+    const prop = { rent: 850, squareMeters: 75 };
+
+    const r = computeMatchScore(client, ownerReqs, prop);
+    expect(r.hardFails).toHaveLength(0);
+    expect(r.score).toBeCloseTo(2 / 3, 5);
+  });
+
+  test("score defaults to 1 when only high requirements match", () => {
+    const client = { maxPrice: 950, minSqm: 60, familyStatus: "Couple" };
+    const ownerReqs = [
+      { name: "familyStatus", value: "couple", importance: "high" },
+      { name: "pets", value: false, importance: "high" },
+    ];
+    const prop = { rent: 900, squareMeters: 70 };
+
+    const r = computeMatchScore(client, ownerReqs, prop);
+    expect(r.hardFails).toHaveLength(0);
+    expect(r.score).toBe(1);
+  });
+
+  test("budget still enforces a hard fail", () => {
     const client = { maxPrice: 700, minSqm: 50 };
-    const ownerReqs = { furnished: true };
-    const prop = { rent: 800, squareMeters: 60 };
+    const ownerReqs = [];
+    const prop = { rent: 750, squareMeters: 60 };
 
     const r = computeMatchScore(client, ownerReqs, prop);
     expect(r.score).toBe(0);
     expect(r.hardFails).toContain("budget");
-  });
-
-  test("fails on sqm (should exclude: score = 0)", () => {
-    const client = { maxPrice: 1200, minSqm: 90 };
-    const ownerReqs = {};
-    const prop = { rent: 1000, squareMeters: 70 };
-
-    const r = computeMatchScore(client, ownerReqs, prop);
-    expect(r.score).toBe(0);
-    expect(r.hardFails).toContain("sqm");
-  });
-
-  test("≥50% threshold with mixed soft fields", () => {
-    const client = { maxPrice: 1000, minSqm: 50, familyStatus: "Couple", parking: true };
-    const ownerReqs = { furnished: true, familyStatus: "Couple", parking: true };
-    const prop = { rent: 950, squareMeters: 60, bedrooms: 2, bathrooms: 1 };
-
-    const r = computeMatchScore(client, ownerReqs, prop);
-    expect(r.hardFails).toBeUndefined();
-    expect(r.score).toBeGreaterThanOrEqual(0.5);
   });
 });

--- a/backend/models/property.js
+++ b/backend/models/property.js
@@ -54,6 +54,11 @@ const mongoose = require("mongoose");
     {
       name: { type: String, required: true },
       value: { type: mongoose.Schema.Types.Mixed, required: true },
+      importance: {
+        type: String,
+        enum: ["high", "medium", "low"],
+        default: "low",
+      },
     },
   ],
 

--- a/backend/utils/matching.js
+++ b/backend/utils/matching.js
@@ -1,95 +1,160 @@
 // backend/utils/matching.js
-const cap = (s) => (s ? s[0].toUpperCase() + s.slice(1).toLowerCase() : "");
+const prefKeyMap = {
+  furnished: "furnished",
+  parking: "parking",
+  elevator: "elevator",
+  haselevator: "elevator",
+  pets: "pets",
+  petsallowed: "pets",
+  smoker: "smoker",
+  smokingallowed: "smoker",
+  familystatus: "familyStatus",
+  maxprice: "maxPrice",
+  rentmax: "maxPrice",
+  salemax: "maxPrice",
+  minsqm: "minSqm",
+  sqmmin: "minSqm",
+  bedrooms: "minBedrooms",
+  minbedrooms: "minBedrooms",
+  bathrooms: "minBathrooms",
+  minbathrooms: "minBathrooms",
+};
 
-// Αν τα owner requirements έρχονται σαν array [{name,value}], κάν' τα object
-function normalizeOwnerReqs(reqs) {
-  if (!reqs) return {};
+const normalizeImportance = (value) =>
+  String(value).toLowerCase() === "high" ? "high" : "low";
+
+const normalizeRequirementsList = (reqs) => {
+  if (!reqs) return [];
   if (Array.isArray(reqs)) {
-    return reqs.reduce((acc, cur) => {
-      if (!cur || typeof cur.name !== "string") return acc;
-      acc[cur.name] = cur.value;
-      return acc;
-    }, {});
+    return reqs
+      .filter(
+        (item) =>
+          item &&
+          typeof item === "object" &&
+          typeof item.name === "string" &&
+          Object.prototype.hasOwnProperty.call(item, "value")
+      )
+      .map((item) => ({
+        name: item.name,
+        value: item.value,
+        importance: normalizeImportance(item.importance),
+      }));
   }
-  return reqs; // ήδη object (π.χ. tenantRequirements)
+  if (typeof reqs === "object") {
+    return Object.entries(reqs).map(([name, value]) => ({
+      name,
+      value,
+      importance: "low",
+    }));
+  }
+  return [];
+};
+
+// Backwards compatibility helper used by some legacy code/tests
+function normalizeOwnerReqs(reqs) {
+  return normalizeRequirementsList(reqs).reduce((acc, cur) => {
+    acc[cur.name] = cur.value;
+    return acc;
+  }, {});
 }
 
-function truthy(v) {
-  return v === true || v === "true" || v === "1";
-}
+const normalizeValue = (value) => {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed === "") return "";
+    const lower = trimmed.toLowerCase();
+    if (lower === "true") return true;
+    if (lower === "false") return false;
+    const num = Number(trimmed);
+    if (!Number.isNaN(num)) return num;
+    return lower;
+  }
+  return value;
+};
+
+const getClientValue = (client, name) => {
+  if (!name) return undefined;
+  const key = prefKeyMap[name.toLowerCase()] || name;
+  return client[key];
+};
+
+const requirementMatches = (ownerValueRaw, clientValueRaw) => {
+  const ownerValue = normalizeValue(ownerValueRaw);
+  const clientValue =
+    clientValueRaw === undefined || clientValueRaw === null
+      ? undefined
+      : normalizeValue(clientValueRaw);
+
+  if (typeof ownerValue === "boolean") {
+    if (ownerValue === true) {
+      return clientValue !== false;
+    }
+    return clientValue !== true;
+  }
+
+  if (clientValue === undefined || clientValue === "") {
+    return false;
+  }
+
+  if (typeof ownerValue === "number" && typeof clientValue === "number") {
+    return ownerValue === clientValue;
+  }
+
+  return ownerValue === clientValue;
+};
 
 function computeMatchScore(clientFilters = {}, ownerReqsRaw = {}, prop = {}) {
-  const owner = normalizeOwnerReqs(ownerReqsRaw);
   const client = { ...clientFilters };
+  const ownerRequirements = normalizeRequirementsList(ownerReqsRaw);
 
   const hardFails = [];
-  let considered = 0;
-  let matched = 0;
 
   const rent = prop.rent ?? prop.price;
   const sqm = prop.squareMeters ?? prop.surface;
 
-  // --- Hard constraints: budget / sqm / bedrooms / bathrooms ---
   if (client.maxPrice != null && rent != null) {
-    considered++;
     if (Number(client.maxPrice) < Number(rent)) hardFails.push("budget");
-    else matched++;
   }
   if (client.minSqm != null && sqm != null) {
-    considered++;
     if (Number(client.minSqm) > Number(sqm)) hardFails.push("sqm");
-    else matched++;
   }
   if (client.minBedrooms != null && prop.bedrooms != null) {
-    considered++;
     if (Number(client.minBedrooms) > Number(prop.bedrooms)) hardFails.push("bedrooms");
-    else matched++;
   }
   if (client.minBathrooms != null && prop.bathrooms != null) {
-    considered++;
     if (Number(client.minBathrooms) > Number(prop.bathrooms)) hardFails.push("bathrooms");
-    else matched++;
   }
 
-  // --- Owner-driven prefs (μετράνε μόνο αν ο owner τα έχει ορίσει) ---
-  const softBool = (keyProp, keyClient, keyOwner = keyProp) => {
-    if (owner[keyOwner] === undefined) return;
-    considered++;
-    const ownerNeeds = truthy(owner[keyOwner]); // owner ζητάει το feature;
-    const clientSaysNo = client[keyClient] === false || client[keyClient] === "false";
-    if (ownerNeeds && clientSaysNo) return; // mismatch
-    matched++; // είτε owner δεν απαιτεί, είτε client δεν το αρνείται ρητά
-  };
+  let softTotal = 0;
+  let softMatched = 0;
 
-  softBool("furnished", "furnished");
-  softBool("parking", "parking");
-  softBool("elevator", "elevator", "hasElevator"); // καλύπτει και hasElevator
+  for (const requirement of ownerRequirements) {
+    if (!requirement || typeof requirement.name !== "string") continue;
+    if (!Object.prototype.hasOwnProperty.call(requirement, "value")) continue;
 
-  // Family status exact match όταν και οι δύο το έχουν
-  const fsO = cap(owner.familyStatus);
-  const fsC = cap(client.familyStatus);
-  if (fsO && fsC) {
-    considered++;
-    if (fsO === fsC) matched++;
+    const importance = normalizeImportance(requirement.importance);
+    const name = requirement.name.trim();
+    if (!name) continue;
+
+    const clientValue = getClientValue(client, name);
+    const matches = requirementMatches(requirement.value, clientValue);
+
+    if (importance === "high") {
+      if (!matches) {
+        hardFails.push(name);
+      }
+    } else {
+      softTotal += 1;
+      if (matches) softMatched += 1;
+    }
   }
 
-  // Pets / smoker (owner μπορεί να απαγορεύει)
-  if (owner.pets === false) {
-    considered++;
-    if (client.pets === true) {
-      // mismatch
-    } else matched++;
-  }
-  if (owner.smoker === false) {
-    considered++;
-    if (client.smoker === true) {
-      // mismatch
-    } else matched++;
+  if (hardFails.length) {
+    return { score: 0, hardFails, softMatched, softTotal };
   }
 
-  if (hardFails.length) return { score: 0, considered, matched, hardFails };
-  const score = considered ? matched / considered : 1; // αν δεν έχουμε συγκρίσιμα, μην κόβεις
-  return { score, considered, matched };
+  const score = softTotal > 0 ? softMatched / softTotal : 1;
+  return { score, hardFails, softMatched, softTotal };
 }
 
 module.exports = { computeMatchScore, normalizeOwnerReqs };

--- a/frontend/src/pages/AddProperty.js
+++ b/frontend/src/pages/AddProperty.js
@@ -22,6 +22,7 @@ export default function AddProperty() {
   });
 
   const [requirements, setRequirements] = useState({});
+  const [requirementsImportance, setRequirementsImportance] = useState({});
     
   const [images, setImages] = useState([]);
   const [floorPlan, setFloorPlan] = useState(null);
@@ -51,7 +52,12 @@ export default function AddProperty() {
       if (form.squareMeters) fd.append('squareMeters', form.squareMeters);
 
        // requirements
-      const reqsAsArray = Object.entries(requirements).map(([name, value]) => ({ name, value }));
+      const reqsAsArray = Object.entries(requirements).map(([name, value]) => ({
+        name,
+        value,
+        importance:
+          requirementsImportance?.[name] === 'high' ? 'high' : 'low',
+      }));
       if (reqsAsArray.length > 0) {
         fd.append('requirements', JSON.stringify(reqsAsArray));
       }
@@ -128,7 +134,12 @@ export default function AddProperty() {
         </div>
 
        <h5 className="mt-3">Property Details</h5>
-        <RequirementsForm values={requirements} setValues={setRequirements} />
+        <RequirementsForm
+          values={requirements}
+          setValues={setRequirements}
+          importanceValues={requirementsImportance}
+          setImportanceValues={setRequirementsImportance}
+        />
 
         <div className="mb-3">
           <label className="form-label">Images</label>

--- a/frontend/src/pages/EditProperty.js
+++ b/frontend/src/pages/EditProperty.js
@@ -52,6 +52,7 @@ function EditProperty() {
     ownerNotes: '',
   });
    const [requirements, setRequirements] = useState({});
+   const [requirementsImportance, setRequirementsImportance] = useState({});
 
   // ---- Google Maps ----
   const apiKey = getMapsApiKey();
@@ -126,11 +127,21 @@ function EditProperty() {
           ownerNotes: p.ownerNotes || '',
         });
         if (Array.isArray(p.requirements)) {
-          const reqs = p.requirements.reduce((acc, req) => {
-            acc[req.name] = req.value;
-            return acc;
-          }, {});
-          setRequirements(reqs);
+          const { values: reqValues, importance: reqImportance } = p.requirements.reduce(
+            (acc, req) => {
+              if (req && typeof req.name === 'string') {
+                acc.values[req.name] = req.value;
+                acc.importance[req.name] = req.importance === 'high' ? 'high' : 'low';
+              }
+              return acc;
+            },
+            { values: {}, importance: {} }
+          );
+          setRequirements(reqValues);
+          setRequirementsImportance(reqImportance);
+        } else {
+          setRequirements({});
+          setRequirementsImportance({});
         }
 
 
@@ -168,7 +179,11 @@ function EditProperty() {
       if (v !== undefined && v !== null && v !== '') data.append(k, v);
     });
 
-    const reqsAsArray = Object.entries(requirements).map(([name, value]) => ({ name, value }));
+    const reqsAsArray = Object.entries(requirements).map(([name, value]) => ({
+      name,
+      value,
+      importance: requirementsImportance?.[name] === 'high' ? 'high' : 'low',
+    }));
     if (reqsAsArray.length > 0) {
       data.append('requirements', JSON.stringify(reqsAsArray));
     }
@@ -304,7 +319,12 @@ function EditProperty() {
           
           <hr className="my-3" />
            <h5 className="fw-bold">Property Details</h5>
-          <RequirementsForm values={requirements} setValues={setRequirements} />
+          <RequirementsForm
+            values={requirements}
+            setValues={setRequirements}
+            importanceValues={requirementsImportance}
+            setImportanceValues={setRequirementsImportance}
+          />
 
           {/* EXISTING MEDIA */}
           <hr className="my-4" />


### PR DESCRIPTION
## Summary
- add an importance attribute to stored property requirements and normalize incoming payloads
- update tenant matching logic to hard-fail on high priority requirements and compute soft scores for low priority ones
- surface importance selectors on property forms and extend tests to cover the new behaviour

## Testing
- npm test (backend)


------
https://chatgpt.com/codex/tasks/task_e_68cc01f9f8648329ac5486ea54e5f02d