### PR TITLE
Refresh messaging UI to match application styling

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,7 +19,7 @@
         "nodemailer": "^7.0.5",
         "path-to-regexp": "^8.2.0",
         "react-circular-progressbar": "^2.2.0",
-        "socket.io": "^4.7.5"
+        "socket.io": "^4.8.1"
       },
       "devDependencies": {
         "jest": "^30.1.3",
@@ -5413,7 +5413,6 @@
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
       "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
-      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,7 @@
     "nodemailer": "^7.0.5",
     "path-to-regexp": "^8.2.0",
     "react-circular-progressbar": "^2.2.0",
-    "socket.io": "^4.7.5"
+    "socket.io": "^4.8.1"
   },
   "devDependencies": {
     "jest": "^30.1.3",

--- a/frontend/src/pages/Chat.css
+++ b/frontend/src/pages/Chat.css
@@ -1,0 +1,205 @@
+.glass-panel {
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  box-shadow: 0 24px 55px rgba(0, 0, 0, 0.1);
+  backdrop-filter: blur(18px);
+}
+
+.chat-card {
+  overflow: hidden;
+}
+
+.chat-property {
+  padding: 1.25rem 1.5rem 0;
+}
+
+.chat-property-thumb {
+  width: 120px;
+  height: 90px;
+  border-radius: 16px;
+  overflow: hidden;
+  background: #f3f4f6;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.chat-property-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.chat-property-loading {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(243, 244, 246, 0.6);
+  border-radius: 16px;
+}
+
+.chat-body {
+  padding: 1.5rem;
+  padding-top: 0.75rem;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(234, 247, 236, 0.9));
+}
+
+.chat-counterpart-avatar {
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  overflow: hidden;
+  border: 3px solid #fff;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.12);
+}
+
+.chat-counterpart-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.chat-scroll {
+  max-height: 440px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding-right: 0.5rem;
+}
+
+.chat-scroll::-webkit-scrollbar {
+  width: 6px;
+}
+
+.chat-scroll::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.5);
+  border-radius: 999px;
+}
+
+.message-row {
+  display: flex;
+}
+
+.message-row.other {
+  justify-content: flex-start;
+}
+
+.message-row.self {
+  justify-content: flex-end;
+}
+
+.message-bubble {
+  padding: 0.85rem 1rem;
+  border-radius: 18px;
+  max-width: min(70%, 420px);
+  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.12);
+  position: relative;
+}
+
+.bubble-other {
+  background: #ffffff;
+  color: #1f2937;
+}
+
+.bubble-self {
+  background: linear-gradient(135deg, #006400, #32cd32);
+  color: #fff;
+}
+
+.message-meta {
+  display: block;
+  font-size: 0.75rem;
+  margin-top: 0.45rem;
+  opacity: 0.8;
+}
+
+.bubble-self .message-meta {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.chat-input-group {
+  border: 1px solid rgba(209, 213, 219, 0.8);
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: inset 0 1px 3px rgba(15, 118, 110, 0.05);
+}
+
+.chat-input {
+  border: none;
+  resize: none;
+  padding: 0.85rem 1.2rem;
+  background: transparent;
+}
+
+.chat-input:focus {
+  box-shadow: none;
+}
+
+.chat-send-btn {
+  border: none;
+  border-radius: 0;
+  background: linear-gradient(135deg, #006400, #32cd32);
+  color: #fff;
+  padding: 0 1.5rem;
+  font-weight: 600;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.chat-send-btn:hover {
+  opacity: 0.9;
+  transform: translateX(1px);
+}
+
+.back-button {
+  background-color: #fff;
+  border: 1px solid #dee2e6;
+  border-radius: 50%;
+  width: 42px;
+  height: 42px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.back-button:hover {
+  background-color: #f3f4f6;
+  border-color: #cbd5f5;
+}
+
+@media (max-width: 768px) {
+  .chat-property {
+    flex-direction: column;
+    align-items: stretch !important;
+    text-align: center;
+  }
+
+  .chat-property-thumb {
+    width: 100%;
+    height: 160px;
+  }
+
+  .chat-counterpart {
+    flex-direction: column;
+    align-items: flex-start !important;
+  }
+
+  .chat-counterpart-avatar {
+    width: 46px;
+    height: 46px;
+  }
+
+  .chat-scroll {
+    max-height: 360px;
+  }
+
+  .message-bubble {
+    max-width: 100%;
+  }
+}

--- a/frontend/src/pages/Chat.js
+++ b/frontend/src/pages/Chat.js
@@ -1,5 +1,5 @@
-import React, { useState, useEffect, useMemo, useRef} from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 import io from 'socket.io-client';
 import { getMessages, sendMessage } from '../services/messagesService';
 import { useAuth } from '../context/AuthContext';
@@ -11,14 +11,34 @@ import {
   InputGroup,
   Modal,
   Alert,
+  Badge,
+  Spinner,
 } from 'react-bootstrap';
 import api from '../api';
 import { proposeAppointment } from '../services/appointmentsService';
+import Logo from '../components/Logo';
+import './Chat.css';
 
+const API_ORIGIN =
+  (process.env.REACT_APP_API_URL ? process.env.REACT_APP_API_URL.replace(/\/+$/, '') : '') ||
+  (typeof window !== 'undefined' ? window.location.origin : '');
+
+function normalizeUploadPath(src) {
+  if (!src) return '';
+  if (src.startsWith('http')) return src;
+  const clean = src.replace(/^\/+/, '');
+  return clean.startsWith('uploads/') ? `/${clean}` : `/uploads/${clean}`;
+}
+
+const assetUrl = (src, fallback) => {
+  if (!src) return fallback;
+  if (src.startsWith('http')) return src;
+  return `${API_ORIGIN}${normalizeUploadPath(src)}`;
+};
 
 function Chat() {
   const { propertyId, userId: receiverId } = useParams();
-  const { user, token } = useAuth();
+  const { user, token, logout } = useAuth();
   const navigate = useNavigate();
   const [messages, setMessages] = useState([]);
   const [newMessage, setNewMessage] = useState('');
@@ -30,22 +50,48 @@ function Chat() {
   const [proposalError, setProposalError] = useState('');
   const [proposalSuccess, setProposalSuccess] = useState('');
   const [submittingProposal, setSubmittingProposal] = useState(false);
+  const [otherUser, setOtherUser] = useState(null);
   const socket = useRef(null);
   const messagesEndRef = useRef(null);
 
   const SOCKET_URL = process.env.REACT_APP_API_URL || (typeof window !== 'undefined' ? window.location.origin : '');
 
+  const pageGradient = useMemo(
+    () => ({
+      minHeight: '100vh',
+      background: `radial-gradient(700px circle at 18% 12%, rgba(255,255,255,.55), rgba(255,255,255,0) 42%),
+       linear-gradient(135deg, #eaf7ec 0%, #e4f8ee 33%, #e8fbdc 66%, #f6fff2 100%)`,
+    }),
+    []
+  );
+
+  const profileImg = user?.profilePicture
+    ? (user.profilePicture.startsWith('http')
+        ? user.profilePicture
+        : `${API_ORIGIN}${normalizeUploadPath(user.profilePicture)}`)
+    : '/default-avatar.jpg';
+
   useEffect(() => {
     const fetchMessages = async () => {
       try {
         const allMessages = await getMessages();
-        const filteredMessages = allMessages.filter(
-          (msg) =>
-            msg.propertyId?._id === propertyId &&
-            ((msg.senderId?._id === user.id && msg.receiverId?._id === receiverId) ||
-              (msg.senderId?._id === receiverId && msg.receiverId?._id === user.id))
-        );
+        const filteredMessages = allMessages
+          .filter(
+            (msg) =>
+              msg.propertyId?._id === propertyId &&
+              ((msg.senderId?._id === user.id && msg.receiverId?._id === receiverId) ||
+                (msg.senderId?._id === receiverId && msg.receiverId?._id === user.id))
+          )
+          .sort((a, b) => new Date(a.timeStamp) - new Date(b.timeStamp));
+
         setMessages(filteredMessages);
+
+        const participant = filteredMessages
+          .map((msg) => (msg.senderId?._id === user.id ? msg.receiverId : msg.senderId))
+          .find(Boolean);
+        if (participant) {
+          setOtherUser(participant);
+        }
       } catch (err) {
         console.error('Failed to load messages', err);
       }
@@ -71,34 +117,11 @@ function Chat() {
            (newMessage.senderId?._id === receiverId && newMessage.receiverId?._id === user.id))
         ) {
           setMessages((prev) => [...prev, newMessage]);
-        }
-      });
-
-      return () => {
-        socket.current.disconnect();
-      };
-    }
-  }, [user?.id, propertyId, receiverId, SOCKET_URL]);
-
-  useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages]);
-
-  useEffect(() => {
-    if (user?.id) {
-      socket.current = io(SOCKET_URL, {
-        reconnectionAttempts: 3,
-        transports: ['websocket'],
-      });
-      socket.current.emit('join', user.id);
-
-      socket.current.on('newMessage', (newMessage) => {
-        if (
-          newMessage.propertyId?._id === propertyId &&
-          ((newMessage.senderId?._id === user.id && newMessage.receiverId?._id === receiverId) ||
-           (newMessage.senderId?._id === receiverId && newMessage.receiverId?._id === user.id))
-        ) {
-          setMessages((prev) => [...prev, newMessage]);
+          const participant =
+            newMessage.senderId?._id === user.id ? newMessage.receiverId : newMessage.senderId;
+          if (participant) {
+            setOtherUser(participant);
+          }
         }
       });
 
@@ -164,7 +187,7 @@ function Chat() {
       alert('Failed to send message.');
     }
   };
-    const handleProposalSlotChange = (index, value) => {
+  const handleProposalSlotChange = (index, value) => {
     setSlotInputs((prev) => {
       const next = [...prev];
       next[index] = value;
@@ -230,87 +253,223 @@ function Chat() {
   };
 
 
+  const handleLogout = () => {
+    logout();
+    navigate('/');
+  };
+
+  const otherUserAvatar = otherUser?.profilePicture
+    ? assetUrl(otherUser.profilePicture, '/default-avatar.jpg')
+    : '/default-avatar.jpg';
+
+  const propertyImage = property?.images?.[0]
+    ? assetUrl(property.images[0], 'https://placehold.co/320x220?text=No+Image')
+    : 'https://placehold.co/320x220?text=No+Image';
+
+  const propertyTypeVariant = property?.type === 'rent' ? 'info' : 'success';
+
+  const propertyLocation = property?.location || property?.city || property?.address || '';
+
+  const formattedReceiverName = otherUser?.name || 'Conversation';
+
   return (
-    <Container className="mt-4">
-      <Button
-        variant="outline-secondary"
-        className="mb-3"
-        onClick={() => navigate(-1)}
+    <div style={pageGradient} className="pb-5">
+      <nav
+        className="navbar navbar-expand-lg px-4 py-3 shadow-sm"
+        style={{
+          background: 'rgba(255,255,255,0.72)',
+          backdropFilter: 'blur(8px)',
+          WebkitBackdropFilter: 'blur(8px)',
+          position: 'relative',
+          zIndex: 5000,
+        }}
       >
-        Back
-      </Button>
-      <h3>Conversation</h3>
-      <Card>
-        <Card.Body style={{ height: '400px', overflowY: 'auto' }}>
-          {propertyError && (
-            <Alert variant="danger" className="mb-3">
-              {propertyError}
-            </Alert>
-          )}
-          {proposalSuccess && (
-            <Alert
-              variant="success"
-              className="mb-3"
-              onClose={() => setProposalSuccess('')}
-              dismissible
+        <Link to="/dashboard" className="navbar-brand">
+          <Logo as="h5" className="mb-0 logo-in-nav" />
+        </Link>
+        <button
+          className="navbar-toggler"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#navContent"
+          aria-controls="navContent"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
+        >
+          <span className="navbar-toggler-icon"></span>
+        </button>
+        <div className="collapse navbar-collapse" id="navContent">
+          <div className="navbar-nav ms-auto align-items-center">
+            <Link to="/appointments" className="nav-link text-dark">Appointments</Link>
+            <Link to="/messages" className="nav-link text-dark position-relative">Messages</Link>
+            {user?.role !== 'owner' && (
+              <Link to="/favorites" className="nav-link text-dark">Favorites</Link>
+            )}
+            <Link to="/profile" className="nav-link">
+              <img
+                src={profileImg}
+                alt="Profile"
+                className="rounded-circle"
+                style={{ width: 32, height: 32, objectFit: 'cover', border: '2px solid #e5e7eb' }}
+              />
+            </Link>
+            <button
+              className="btn btn-outline-danger rounded-pill px-3 mt-2 mt-lg-0 ms-lg-2"
+              onClick={handleLogout}
             >
-              {proposalSuccess}
-            </Alert>
-          )}
-          {messages.map((msg) => (
-            <div
-              key={msg._id}
-              className={`d-flex mb-2 ${
-                msg.senderId?._id === user.id ? 'justify-content-end' : ''
-              }`}
+              Logout
+            </button>
+          </div>
+        </div>
+      </nav>
+
+      <Container className="py-4" style={{ maxWidth: 980 }}>
+        <div className="d-flex align-items-center justify-content-between flex-wrap gap-3 mb-4">
+          <div className="d-flex align-items-center gap-3">
+            <Button
+              variant="light"
+              onClick={() => navigate('/messages')}
+              className="p-2 back-button"
             >
-              <div
-                className={`p-2 rounded ${
-                  msg.senderId?._id === user.id
-                    ? 'bg-primary text-white'
-                    : 'bg-light'
-                }`}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                fill="currentColor"
+                className="bi bi-arrow-left"
+                viewBox="0 0 16 16"
               >
-                <p className="mb-1">{msg.content}</p>
-                <small className="text-muted">
-                  {new Date(msg.timeStamp).toLocaleString()}
-                </small>
+                <path d="M15 8a.5.5 0 0 0-.5-.5H2.707l3.147-3.146a.5.5 0 1 0-.708-.708l-4 4a.5.5 0 0 0 0 .708l4 4a.5.5 0 0 0 .708-.708L2.707 8.5H14.5A.5.5 0 0 0 15 8z" />
+              </svg>
+            </Button>
+            <div>
+              <h2 className="fw-bold mb-1">{formattedReceiverName}</h2>
+              <p className="text-muted mb-0 small">Conversation regarding this property</p>
+            </div>
+          </div>
+
+          {canProposeAppointment && (
+            <Button
+              variant="success"
+              className="rounded-pill px-3"
+              onClick={() => {
+                setShowProposalModal(true);
+                setProposalError('');
+              }}
+              disabled={loadingProperty}
+            >
+              Propose appointment
+            </Button>
+          )}
+        </div>
+
+        <Card className="shadow-sm border-0 glass-panel chat-card">
+          {(property || loadingProperty || propertyError) && (
+            <Card.Header className="bg-transparent border-0 pb-0">
+              <div className="chat-property d-flex align-items-start gap-3">
+                <div className="chat-property-thumb">
+                  {loadingProperty ? (
+                    <div className="chat-property-loading">
+                      <Spinner animation="border" size="sm" />
+                    </div>
+                  ) : (
+                    <img src={propertyImage} alt={property?.title || 'Property'} />
+                  )}
+                </div>
+                <div className="flex-grow-1">
+                  {propertyError ? (
+                    <Alert variant="danger" className="mb-0 py-2">
+                      {propertyError}
+                    </Alert>
+                  ) : (
+                    property && (
+                      <>
+                        <div className="d-flex flex-wrap align-items-center gap-2 mb-1">
+                          <h5 className="mb-0 me-2">{property.title}</h5>
+                          {property?.type && (
+                            <Badge bg={propertyTypeVariant} pill>
+                              {property.type === 'rent' ? 'For Rent' : 'For Sale'}
+                            </Badge>
+                          )}
+                          {property?.status && (
+                            <Badge bg={property.status === 'available' ? 'success' : 'secondary'} pill>
+                              {property.status}
+                            </Badge>
+                          )}
+                        </div>
+                        <p className="text-muted small mb-0">{propertyLocation}</p>
+                      </>
+                    )
+                  )}
+                </div>
+              </div>
+            </Card.Header>
+          )}
+
+          {proposalSuccess && (
+            <Card.Body className="bg-transparent pt-3 pb-0">
+              <Alert
+                variant="success"
+                className="mb-0"
+                onClose={() => setProposalSuccess('')}
+                dismissible
+              >
+                {proposalSuccess}
+              </Alert>
+            </Card.Body>
+          )}
+
+          <Card.Body className="chat-body">
+            <div className="chat-counterpart d-flex align-items-center gap-3 mb-3">
+              <div className="chat-counterpart-avatar">
+                <img src={otherUserAvatar} alt={formattedReceiverName} />
+              </div>
+              <div>
+                <h6 className="mb-0">{formattedReceiverName}</h6>
+                {otherUser?.email && <small className="text-muted">{otherUser.email}</small>}
               </div>
             </div>
-          ))}
-          <div ref={messagesEndRef} />
-          <div ref={messagesEndRef} />
-        </Card.Body>
-        <Card.Footer>
-          {canProposeAppointment && (
-            <div className="d-flex justify-content-between flex-wrap gap-2 mb-3">
-              <Button
-                variant="success"
-                onClick={() => {
-                  setShowProposalModal(true);
-                  setProposalError('');
-                }}
-                disabled={loadingProperty}
-              >
-                Propose appointment
-              </Button>
+            <div className="chat-scroll">
+              {messages.map((msg) => {
+                const isSelf = msg.senderId?._id === user.id;
+                return (
+                  <div
+                    key={msg._id}
+                    className={`message-row ${isSelf ? 'self' : 'other'}`}
+                  >
+                    <div className={`message-bubble ${isSelf ? 'bubble-self' : 'bubble-other'}`}>
+                      <p className="mb-1">{msg.content}</p>
+                      <span className="message-meta">
+                        {new Date(msg.timeStamp).toLocaleString()}
+                      </span>
+                    </div>
+                  </div>
+                );
+              })}
+              <div ref={messagesEndRef} />
             </div>
-          )}
-          <Form onSubmit={handleSend}>
-            <InputGroup>
-              <Form.Control
-                as="textarea"
-                value={newMessage}
-                onChange={(e) => setNewMessage(e.target.value)}
-                placeholder="Type your message..."
-                required
-              />
-              <Button type="submit">Send</Button>
-            </InputGroup>
-          </Form>
-        </Card.Footer>
-      </Card>
-       <Modal
+          </Card.Body>
+          <Card.Footer className="bg-transparent border-0 pt-0">
+            <Form onSubmit={handleSend}>
+              <InputGroup className="chat-input-group">
+                <Form.Control
+                  as="textarea"
+                  rows={1}
+                  value={newMessage}
+                  onChange={(e) => setNewMessage(e.target.value)}
+                  placeholder="Type your message..."
+                  required
+                  className="chat-input"
+                />
+                <Button type="submit" className="chat-send-btn">
+                  Send
+                </Button>
+              </InputGroup>
+            </Form>
+          </Card.Footer>
+        </Card>
+
+        <Modal
         show={showProposalModal}
         onHide={() => {
           setShowProposalModal(false);
@@ -382,8 +541,8 @@ function Chat() {
           </Modal.Footer>
         </Form>
       </Modal>
-      
-    </Container>
+      </Container>
+    </div>
   );
 }
 

--- a/frontend/src/pages/Messages.css
+++ b/frontend/src/pages/Messages.css
@@ -1,66 +1,148 @@
+.glass-panel {
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.08);
+  backdrop-filter: blur(18px);
+}
+
+.conversation-list {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.conversation-list .list-group-item {
+  border: none;
+  padding: 0;
+  background: transparent;
+}
+
 .conversation-item {
-  border-radius: 12px;
-  margin-bottom: 12px;
-  transition: background-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
-  border: 1px solid #e9ecef;
+  border-radius: 18px;
+  border: 1px solid rgba(209, 213, 219, 0.6);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.95), rgba(234, 247, 236, 0.9));
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .conversation-item:hover {
-  background-color: #f8f9fa;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+  transform: translateY(-3px);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.1);
+}
+
+.conversation-inner {
+  display: flex;
+  gap: 1.5rem;
+  align-items: stretch;
+}
+
+.conversation-media {
+  position: relative;
+  width: 140px;
+  flex-shrink: 0;
+}
+
+.conversation-property-thumb {
+  width: 100%;
+  height: 100px;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+}
+
+.conversation-property-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.conversation-avatar {
+  position: absolute;
+  bottom: -18px;
+  left: 16px;
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  border: 3px solid #fff;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
+  overflow: hidden;
+}
+
+.conversation-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .conversation-content {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 90%;
+  color: #4b5563;
+}
+
+.conversation-date {
+  font-size: 0.8rem;
 }
 
 .back-button {
   background-color: #fff;
   border: 1px solid #dee2e6;
   border-radius: 50%;
-  width: 40px;
-  height: 40px;
+  width: 42px;
+  height: 42px;
   display: flex;
   align-items: center;
   justify-content: center;
-}
-.back-button:hover {
-  background-color: #f8f9fa;
-  border-color: #ced4da;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
 }
 
-@media (max-width: 768px) {
-  .conversation-content {
-    max-width: 80%;
+.back-button:hover {
+  background-color: #f3f4f6;
+  border-color: #cbd5f5;
+}
+
+@media (max-width: 992px) {
+  .conversation-inner {
+    flex-direction: column;
   }
 
-  .d-flex.align-items-center.mb-4 h2 {
-    font-size: 1.5rem;
+  .conversation-media {
+    width: 100%;
+  }
+
+  .conversation-property-thumb {
+    height: 160px;
+  }
+
+  .conversation-avatar {
+    left: auto;
+    right: 16px;
   }
 }
 
 @media (max-width: 576px) {
+  .glass-panel {
+    border-radius: 16px;
+  }
+
+  .conversation-list {
+    padding: 1rem;
+  }
+
+  .conversation-property-thumb {
+    height: 140px;
+  }
+
+  .conversation-avatar {
+    width: 46px;
+    height: 46px;
+    bottom: -14px;
+  }
+
   .conversation-content {
-    max-width: 70%;
-  }
-
-  .conversation-item .d-flex {
-    flex-direction: column;
-    align-items: flex-start !important;
-  }
-
-  .conversation-item img {
-    margin-bottom: 10px;
-  }
-
-  .conversation-item .flex-grow-1 {
-    width: 100%;
-  }
-
-  .d-flex.align-items-center.mb-4 .me-3 {
-      margin-right: 0.5rem !important;
+    white-space: normal;
   }
 }


### PR DESCRIPTION
## Summary
- restyle the conversations list with glass panels, property thumbnails, and status badges to mirror the dashboard aesthetic
- redesign the chat view with shared navigation, property context, and polished message bubbles plus responsive input styling
- add dedicated CSS modules for the messaging pages so their visuals align with the rest of the application

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc019455d08322b2f2c9bc3f6f628d