### PR TITLE
Add appointment detail view to owner calendar

### DIFF
--- a/backend/controllers/appointmentController.js
+++ b/backend/controllers/appointmentController.js
@@ -116,7 +116,7 @@ exports.getAppointmentsByTenant = async (req, res) => {
   try {
     const appointments = await Appointment.find({ tenantId: req.user.userId })
       .populate("propertyId")
-      .populate("ownerId", "name");
+      .populate("ownerId", "name phone");
     res.json(appointments);
   } catch (err) {
     res.status(500).json({ message: "Server error" });
@@ -128,7 +128,7 @@ exports.getAppointmentsByOwner = async (req, res) => {
   try {
     const appointments = await Appointment.find({ ownerId: req.user.userId })
       .populate("propertyId")
-      .populate("tenantId", "name");
+      .populate("tenantId", "name phone");
     res.json(appointments);
   } catch (err) {
     res.status(500).json({ message: "Server error" });
@@ -138,8 +138,8 @@ exports.getAppointmentById = async (req, res) => {
   try {
     const appointment = await Appointment.findById(req.params.appointmentId)
       .populate("propertyId")
-      .populate("ownerId", "name")
-      .populate("tenantId", "name");
+      .populate("ownerId", "name phone")
+      .populate("tenantId", "name phone");
 
     if (!appointment) {
       return res.status(404).json({ message: "Appointment not found" });

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -102,11 +102,6 @@ function Layout({ children }) {
                 <Link to="/dashboard" className="text-dark text-decoration-none">Dashboard</Link>
                 <Link to="/favorites" className="text-dark text-decoration-none">Favorites</Link>
 
-                {/* Appointments προαιρετικά, αν το θες εδώ */}
-                <Link to="/appointments" className="text-dark text-decoration-none">
-                  Appointments
-                </Link>
-
                 {/* Profile: owner => dropdown, αλλιώς απλό κουμπί */}
                 {user.role === 'owner' ? (
                   <div ref={profileMenuRef} className="position-relative">

--- a/frontend/src/pages/Chat.js
+++ b/frontend/src/pages/Chat.js
@@ -358,7 +358,6 @@ function Chat() {
         </button>
         <div className="collapse navbar-collapse" id="navContent">
           <div className="navbar-nav ms-auto align-items-center">
-            <Link to="/appointments" className="nav-link text-dark">Appointments</Link>
             <Link to="/messages" className="nav-link text-dark position-relative">Messages</Link>
             {user?.role !== 'owner' && (
               <Link to="/favorites" className="nav-link text-dark">Favorites</Link>

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -443,7 +443,6 @@ function Dashboard() {
               Add Property
             </Link>
           )}
-          <Link to="/appointments" className="text-dark text-decoration-none">Appointments</Link>
           <Link to="/messages" className="text-dark text-decoration-none position-relative">
             Messages
             {unreadMessages > 0 && (

--- a/frontend/src/pages/Messages.js
+++ b/frontend/src/pages/Messages.js
@@ -128,7 +128,6 @@ function Messages() {
         </button>
         <div className="collapse navbar-collapse" id="navContent">
           <div className="navbar-nav ms-auto align-items-center">
-            <Link to="/appointments" className="nav-link text-dark">Appointments</Link>
             <Link to="/messages" className="nav-link text-dark position-relative">Messages</Link>
             {user?.role !== 'owner' && (
               <Link to="/favorites" className="nav-link text-dark">Favorites</Link>


### PR DESCRIPTION
## Summary
- include phone numbers when populating appointment data on the server
- show owner appointment details when selecting a slot in the calendar
- simplify navigation by removing the dedicated appointments link from toolbars

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc1b6cf86c832285a62a78a5dc55e2