### PR TITLE
Fix Docker networking between frontend and backend

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+Dockerfile
+backend.log
+__tests__
+*.test.js
+coverage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,9 @@ services:
     container_name: myapp-backend
     ports:
       - "5000:5000"
-    env_file:
-      - ./backend/.env
+    environment:
+      - PORT=5000
+      - MONGO_URI=mongodb://mongo:27017/homefinder
     depends_on:
       - mongo
 

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+build
+Dockerfile
+.git
+.gitignore
+frontend.log
+serve.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,5 +7,6 @@ RUN npm run build
 
 FROM nginx:alpine
 COPY --from=build /app/build /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,31 @@
+server {
+  listen 80;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html index.htm;
+
+  location / {
+    try_files $uri /index.html;
+  }
+
+  location /api/ {
+    proxy_pass http://backend:5000/api/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_cache_bypass $http_upgrade;
+  }
+
+  location /socket.io/ {
+    proxy_pass http://backend:5000/socket.io/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_cache_bypass $http_upgrade;
+  }
+}


### PR DESCRIPTION
## Summary
- configure the backend service to use the internal MongoDB host when running with Docker
- add an nginx configuration so the frontend container proxies API and websocket traffic to the backend
- ignore local node_modules and logs from Docker build contexts for smaller, cleaner images

## Testing
- not run (Docker is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68dea01f86d08322bf7bdc9daa5b5bf4