### PR TITLE
Normalize upload path handling across frontend pages

### DIFF
--- a/frontend/src/pages/Chat.js
+++ b/frontend/src/pages/Chat.js
@@ -18,10 +18,9 @@ import api from '../api';
 import { proposeAppointment } from '../services/appointmentsService';
 import Logo from '../components/Logo';
 import './Chat.css';
+import { getApiOrigin, resolveUploadUrl } from '../utils/uploads';
 
-const API_ORIGIN =
-  (process.env.REACT_APP_API_URL ? process.env.REACT_APP_API_URL.replace(/\/+$/, '') : '') ||
-  (typeof window !== 'undefined' ? window.location.origin : '');
+const API_ORIGIN = getApiOrigin();
 
   const resolveSocketUrl = () => {
   const toOrigin = (maybeUrl) => {
@@ -54,17 +53,9 @@ const API_ORIGIN =
   return '';
 };
 
-function normalizeUploadPath(src) {
-  if (!src) return '';
-  if (src.startsWith('http')) return src;
-  const clean = src.replace(/^\/+/, '');
-  return clean.startsWith('uploads/') ? `/${clean}` : `/uploads/${clean}`;
-}
-
 const assetUrl = (src, fallback) => {
-  if (!src) return fallback;
-  if (src.startsWith('http')) return src;
-  return `${API_ORIGIN}${normalizeUploadPath(src)}`;
+  const url = resolveUploadUrl(src, API_ORIGIN);
+  return url || fallback;
 };
 
 function Chat() {
@@ -96,9 +87,7 @@ function Chat() {
   );
 
   const profileImg = user?.profilePicture
-    ? (user.profilePicture.startsWith('http')
-        ? user.profilePicture
-        : `${API_ORIGIN}${normalizeUploadPath(user.profilePicture)}`)
+    ? assetUrl(user.profilePicture, '/default-avatar.jpg')
     : '/default-avatar.jpg';
 
   useEffect(() => {

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -8,6 +8,7 @@ import OwnerAppointmentsCalendar from '../components/OwnerAppointmentsCalendar';
 import PropertyCard from '../components/propertyCard';
 import Logo from '../components/Logo';
 import { getMessages } from '../services/messagesService';
+import { getApiOrigin, resolveUploadUrl } from '../utils/uploads';
 
 /* ---------- helpers (notifications) ---------- */
 const iconForType = (t) => {
@@ -30,15 +31,7 @@ const titleForNote = (n) => {
 };
 
 /* ---------- images (local/ngrok) ---------- */
-const API_ORIGIN =
-  (process.env.REACT_APP_API_URL ? process.env.REACT_APP_API_URL.replace(/\/+$/, '') : '') ||
-  (typeof window !== 'undefined' ? window.location.origin : '');
-function normalizeUploadPath(src) {
-  if (!src) return '';
-  if (src.startsWith('http')) return src;
-  const clean = src.replace(/^\/+/, '');
-  return clean.startsWith('uploads/') ? `/${clean}` : `/uploads/${clean}`;
-}
+const API_ORIGIN = getApiOrigin();
 
 function Dashboard() {
   const { user, logout } = useAuth();
@@ -71,9 +64,7 @@ function Dashboard() {
   const dropdownRef = useRef(null);
 
   const profileImg = user?.profilePicture
-    ? (user.profilePicture.startsWith('http')
-        ? user.profilePicture
-        : `${API_ORIGIN}${normalizeUploadPath(user.profilePicture)}`)
+    ? resolveUploadUrl(user.profilePicture, API_ORIGIN) || '/default-avatar.jpg'
     : '/default-avatar.jpg';
 
   /* ---------- utils ---------- */
@@ -85,10 +76,8 @@ function Dashboard() {
   }), []);
 
   const imgUrl = (src) => {
-    if (!src) return 'https://via.placeholder.com/400x225?text=No+Image';
-    if (src.startsWith('http')) return src;
-    const rel = normalizeUploadPath(src);
-    return `${API_ORIGIN}${rel}`;
+    const url = resolveUploadUrl(src, API_ORIGIN);
+    return url || 'https://via.placeholder.com/400x225?text=No+Image';
   };
 
   const totalPages = useMemo(() => meta?.totalPages || 1, [meta]);

--- a/frontend/src/pages/EditProperty.js
+++ b/frontend/src/pages/EditProperty.js
@@ -9,6 +9,7 @@ import {
   useJsApiLoader,
   StandaloneSearchBox,
 } from '@react-google-maps/api';
+import { getApiOrigin, resolveUploadUrl } from '../utils/uploads';
 
 const containerStyle = { width: '100%', height: '320px' };
 const LIBRARIES = ['places'];
@@ -42,17 +43,8 @@ const featureOptions = [
 ];
 
 // --- image URL helpers (όπως στα άλλα pages: όχι localhost hardcode) ---
-const API_ORIGIN =
-  (process.env.REACT_APP_API_URL ? process.env.REACT_APP_API_URL.replace(/\/+$/, '') : '') ||
-  (typeof window !== 'undefined' ? window.location.origin : '');
-const normalizeUploadPath = (src) => {
-  if (!src) return '';
-  if (src.startsWith('http')) return src;
-  const clean = src.replace(/^\/+/, '');
-  return clean.startsWith('uploads/') ? `/${clean}` : `/uploads/${clean}`;
-};
-const getImageUrl = (path) =>
-  path ? `${API_ORIGIN}${normalizeUploadPath(path)}` : '';
+const API_ORIGIN = getApiOrigin();
+const getImageUrl = (path) => resolveUploadUrl(path, API_ORIGIN);
 
 function EditProperty() {
   const { propertyId } = useParams();

--- a/frontend/src/pages/Favorites.js
+++ b/frontend/src/pages/Favorites.js
@@ -4,18 +4,13 @@ import { getFavorites, removeFavorite } from '../services/favoritesService';
 import { useAuth } from '../context/AuthContext';
 import { useNavigate, Link } from 'react-router-dom';
 import { Container, Button, Card, Row, Col, Badge } from 'react-bootstrap';
+import { getApiOrigin, resolveUploadUrl } from '../utils/uploads';
 
 /* -------- helpers (images) -------- */
-const API_ORIGIN =
-  (process.env.REACT_APP_API_URL ? process.env.REACT_APP_API_URL.replace(/\/+$/, '') : '') ||
-  (typeof window !== 'undefined' ? window.location.origin : '');
+const API_ORIGIN = getApiOrigin();
 
-function normalizeUploadPath(src) {
-  if (!src) return '';
-  if (src.startsWith('http')) return src;
-  const clean = src.replace(/^\/+/, '');
-  const rel = clean.startsWith('uploads/') ? `/${clean}` : `/uploads/${clean}`;
-  return `${API_ORIGIN}${rel}`;
+function getUploadUrl(src) {
+  return resolveUploadUrl(src, API_ORIGIN);
 }
 
 const currency = (n) =>
@@ -123,7 +118,7 @@ export default function Favorites() {
             {favorites.map((fav) => {
               const p = fav.propertyId;
               const img =
-                (p.images?.[0] && normalizeUploadPath(p.images[0])) ||
+                (p.images?.[0] && getUploadUrl(p.images[0])) ||
                 'https://via.placeholder.com/600x360?text=No+Image';
               return (
                 <Col md={6} lg={4} key={p._id}>

--- a/frontend/src/pages/Home.js
+++ b/frontend/src/pages/Home.js
@@ -5,6 +5,7 @@ import api from "../api";
 import GoogleMapView from "../components/GoogleMapView";
 import Logo from "../components/Logo";
 import PropertyCard from "../components/propertyCard";
+import { getApiOrigin, resolveUploadUrl } from "../utils/uploads";
 
 function Home() {
   const [properties, setProperties] = useState([]);
@@ -21,23 +22,12 @@ function Home() {
   }), []);
 
   /* ---------- images (origin-safe) ---------- */
-  const API_ORIGIN =
-    (process.env.REACT_APP_API_URL ? process.env.REACT_APP_API_URL.replace(/\/+$/, "") : "") ||
-    (typeof window !== "undefined" ? window.location.origin : "");
+  const API_ORIGIN = getApiOrigin();
 
-  const normalizeUploadPath = (src) => {
-    if (!src) return "";
-    if (src.startsWith("http")) return src;
-    const clean = src.replace(/^\/+/, "");
-    return clean.startsWith("uploads/") ? `/${clean}` : `/uploads/${clean}`;
+  const imgUrl = (src) => {
+    const url = resolveUploadUrl(src, API_ORIGIN);
+    return url || "https://via.placeholder.com/400x225?text=No+Image";
   };
-
-  const imgUrl = (src) =>
-    src
-      ? src.startsWith("http")
-        ? src
-        : `${API_ORIGIN}${normalizeUploadPath(src)}`
-      : "https://via.placeholder.com/400x225?text=No+Image";
 
   /* ---------- geolocation (optional) ---------- */
   useEffect(() => {

--- a/frontend/src/pages/Messages.js
+++ b/frontend/src/pages/Messages.js
@@ -5,22 +5,13 @@ import { useAuth } from '../context/AuthContext';
 import { useNavigate, Link } from 'react-router-dom';
 import Logo from '../components/Logo';
 import './Messages.css';
+import { getApiOrigin, resolveUploadUrl } from '../utils/uploads';
 
-const API_ORIGIN =
-  (process.env.REACT_APP_API_URL ? process.env.REACT_APP_API_URL.replace(/\/+$/, '') : '') ||
-  (typeof window !== 'undefined' ? window.location.origin : '');
-
-function normalizeUploadPath(src) {
-  if (!src) return '';
-  if (src.startsWith('http')) return src;
-  const clean = src.replace(/^\/+/, '');
-  return clean.startsWith('uploads/') ? `/${clean}` : `/uploads/${clean}`;
-}
+const API_ORIGIN = getApiOrigin();
 
 const assetUrl = (src, fallback) => {
-  if (!src) return fallback;
-  if (src.startsWith('http')) return src;
-  return `${API_ORIGIN}${normalizeUploadPath(src)}`;
+  const url = resolveUploadUrl(src, API_ORIGIN);
+  return url || fallback;
 };
 
 function Messages() {
@@ -33,9 +24,7 @@ function Messages() {
   const navigate = useNavigate();
 
   const profileImg = user?.profilePicture
-    ? (user.profilePicture.startsWith('http')
-        ? user.profilePicture
-        : `${API_ORIGIN}${normalizeUploadPath(user.profilePicture)}`)
+    ? assetUrl(user.profilePicture, '/default-avatar.jpg')
     : '/default-avatar.jpg';
 
   const pageGradient = useMemo(

--- a/frontend/src/pages/MyProperties.js
+++ b/frontend/src/pages/MyProperties.js
@@ -4,6 +4,7 @@ import { useAuth } from '../context/AuthContext';
 import { Link, useNavigate } from 'react-router-dom';
 import api from '../api';
 import { Button, Spinner, Row, Col, Card, Badge, Container } from 'react-bootstrap';
+import { getApiOrigin, resolveUploadUrl } from '../utils/uploads';
 
 export default function MyProperties() {
   const { user } = useAuth();
@@ -19,17 +20,11 @@ export default function MyProperties() {
   }), []);
 
   // --- image URL helpers (no localhost hardcode) ---
-  const API_ORIGIN =
-    (process.env.REACT_APP_API_URL ? process.env.REACT_APP_API_URL.replace(/\/+$/, '') : '') ||
-    (typeof window !== 'undefined' ? window.location.origin : '');
-  const normalizeUploadPath = (src) => {
-    if (!src) return '';
-    if (src.startsWith('http')) return src;
-    const clean = src.replace(/^\/+/, '');
-    return clean.startsWith('uploads/') ? `/${clean}` : `/uploads/${clean}`;
+  const API_ORIGIN = getApiOrigin();
+  const imgUrl = (src) => {
+    const url = resolveUploadUrl(src, API_ORIGIN);
+    return url || 'https://via.placeholder.com/600x360?text=No+Image';
   };
-  const imgUrl = (src) =>
-    src ? `${API_ORIGIN}${normalizeUploadPath(src)}` : 'https://via.placeholder.com/600x360?text=No+Image';
 
   useEffect(() => {
     const load = async () => {

--- a/frontend/src/pages/PropertyDetails.js
+++ b/frontend/src/pages/PropertyDetails.js
@@ -4,6 +4,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import api from '../api';
 import GoogleMapView from '../components/GoogleMapView';
+import { getApiOrigin, resolveUploadUrl } from '../utils/uploads';
 
 function PropertyDetails() {
   const { propertyId } = useParams();
@@ -28,20 +29,11 @@ function PropertyDetails() {
   );
 
   // API origin & image helpers
-  const API_ORIGIN =
-    (process.env.REACT_APP_API_URL
-      ? process.env.REACT_APP_API_URL.replace(/\/+$/, "")
-      : "") || (typeof window !== "undefined" ? window.location.origin : "");
-  const normalizeUploadPath = (src) => {
-    if (!src) return "";
-    if (src.startsWith("http")) return src;
-    const clean = src.replace(/^\/+/, "");
-    return clean.startsWith("uploads/") ? `/${clean}` : `/uploads/${clean}`;
+  const API_ORIGIN = getApiOrigin();
+  const getImageUrl = (path) => {
+    const url = resolveUploadUrl(path, API_ORIGIN);
+    return url || "https://placehold.co/1200x800?text=No+Image";
   };
-  const getImageUrl = (path) =>
-    path
-      ? `${API_ORIGIN}${normalizeUploadPath(path)}`
-      : "https://placehold.co/1200x800?text=No+Image";
 
   // Fetch property & favorites
   useEffect(() => {

--- a/frontend/src/utils/uploads.js
+++ b/frontend/src/utils/uploads.js
@@ -1,0 +1,31 @@
+const API_ORIGIN =
+  (process.env.REACT_APP_API_URL ? process.env.REACT_APP_API_URL.replace(/\/+$/, '') : '') ||
+  (typeof window !== 'undefined' ? window.location.origin : '');
+
+const HTTP_PATTERN = /^https?:\/\//i;
+
+export function getApiOrigin() {
+  return API_ORIGIN;
+}
+
+export function normalizeUploadPath(src) {
+  if (!src) return '';
+  const value = String(src).trim();
+  if (!value) return '';
+  if (HTTP_PATTERN.test(value)) return value;
+  const normalized = value.replace(/\\/g, '/');
+  const withoutLeadingSlash = normalized.replace(/^\/+/, '');
+  if (withoutLeadingSlash.startsWith('uploads/')) {
+    return `/${withoutLeadingSlash}`;
+  }
+  return `/uploads/${withoutLeadingSlash}`;
+}
+
+export function resolveUploadUrl(src, origin = API_ORIGIN) {
+  if (!src) return '';
+  const normalized = normalizeUploadPath(src);
+  if (!normalized || HTTP_PATTERN.test(normalized)) {
+    return normalized;
+  }
+  return `${origin}${normalized}`;
+}


### PR DESCRIPTION
## Summary
- add a shared `utils/uploads` helper to normalize upload paths and share the computed API origin
- update property, chat, and messaging pages to rely on the shared helper so Windows-style paths are converted before prefixing `/uploads`
- ensure profile and property image URLs consistently fall back to placeholders when missing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0da170100832297a2b0546fbf6cee