### PR TITLE
Add lease duration and tenant requirements to property flows

### DIFF
--- a/backend/controllers/propertyController.js
+++ b/backend/controllers/propertyController.js
@@ -38,6 +38,14 @@ const toArray = (v) => {
   return str.split(",").map((s) => s.trim()).filter(Boolean);
 };
 
+const normalizeLeaseDuration = (value) => {
+  if (!hasValue(value)) return undefined;
+  const val = String(value).toLowerCase();
+  if (val === 'short' || val.includes('short')) return 'short';
+  if (val === 'long' || val.includes('long')) return 'long';
+  return undefined;
+};
+
 const normalizeRoommatePreference = (value) => {
   if (!hasValue(value)) return undefined;
   const val = String(value).toLowerCase();
@@ -151,6 +159,7 @@ exports.createProperty = async (req, res) => {
       // listing
       type: b.type, // 'rent'|'sale'
       status: b.status,
+      leaseDuration: normalizeLeaseDuration(b.leaseDuration),
 
       // dimensions (support alias sqm)
       squareMeters: toNum(b.squareMeters ?? b.sqm, parseInt),
@@ -427,6 +436,10 @@ exports.updateProperty = async (req, res) => {
     // type/status
     if (hasValue(b.type)) property.type = b.type;
     if (hasValue(b.status)) property.status = b.status;
+    if (b.leaseDuration !== undefined) {
+      const normalizedLease = normalizeLeaseDuration(b.leaseDuration);
+      property.leaseDuration = normalizedLease ?? '';
+    }
 
     // metrics (support alias 'sqm')
     property.squareMeters = setIfProvided(

--- a/backend/models/property.js
+++ b/backend/models/property.js
@@ -42,6 +42,7 @@ const propertySchema = new mongoose.Schema(
 
     // status
     status: { type: String, enum: ["available", "rented", "sold"], default: "available" },
+    leaseDuration: { type: String, enum: ['', 'short', 'long'], default: '' },
 
     // --- dimensions / βασικά ---
     squareMeters: { type: Number, min: 0 }, // primary

--- a/frontend/src/pages/EditProperty.js
+++ b/frontend/src/pages/EditProperty.js
@@ -75,6 +75,7 @@ function EditProperty() {
     price: '',            // 💶 unified (reads old rent if exists)
     type: 'sale',
     status: 'available',
+    leaseDuration: '',
 
     // basics
     description: '',
@@ -185,6 +186,7 @@ function EditProperty() {
           price: p.price ?? p.rent ?? '',        // 💶 read both, prefer price
           type: p.type || 'sale',
           status: p.status || 'available',
+          leaseDuration: p.leaseDuration || '',
 
           description: p.description || '',
           floor: p.floor ?? '',
@@ -247,6 +249,12 @@ function EditProperty() {
     fetchProperty();
   }, [propertyId]);
 
+  useEffect(() => {
+    if (formData.type !== 'rent' && formData.leaseDuration) {
+      setFormData((prev) => ({ ...prev, leaseDuration: '' }));
+    }
+  }, [formData.type, formData.leaseDuration]);
+
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
 
@@ -296,6 +304,7 @@ function EditProperty() {
       address: formData.address,
       type: formData.type,
       status: formData.status,
+      leaseDuration: formData.leaseDuration,
       price: priceNum, // 💶 send price (not rent)
 
       // basics
@@ -463,6 +472,33 @@ function EditProperty() {
               </select>
             </div>
           </div>
+
+          {formData.type === 'rent' && (
+            <div className="mt-3">
+              <Form.Label className="form-label d-block">Preferred stay length</Form.Label>
+              <div className="d-flex flex-wrap gap-3">
+                <Form.Check
+                  type="radio"
+                  id="leaseDuration-short"
+                  label="Short stay (< 12 months)"
+                  name="leaseDuration"
+                  value="short"
+                  checked={formData.leaseDuration === 'short'}
+                  onChange={handleChange}
+                />
+                <Form.Check
+                  type="radio"
+                  id="leaseDuration-long"
+                  label="Long term (≥ 12 months)"
+                  name="leaseDuration"
+                  value="long"
+                  checked={formData.leaseDuration === 'long'}
+                  onChange={handleChange}
+                />
+              </div>
+              <div className="form-text">Helps match tenants looking for the same commitment length.</div>
+            </div>
+          )}
 
           {/* DESCRIPTION */}
           <div className="mb-3 mt-3">


### PR DESCRIPTION
## Summary
- add lease duration controls and tenant requirement inputs to the add property workflow
- persist normalized lease duration on the property model/controller
- expose lease duration alongside existing tenant requirement fields in the edit property page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e50830531c8322996e3fd3edb3fb7a