### PR TITLE
Feat: Match Clients and Messaging Controls

### DIFF
--- a/backend/__tests__/messages.socket.test.js
+++ b/backend/__tests__/messages.socket.test.js
@@ -70,8 +70,9 @@ const property = await Property.create({
 
     // 3) Token για τον sender
     // ⚠️ Πρόσεξε: το payload πρέπει να ταιριάζει με το auth middleware σου
-    const senderToken = jwt.sign(
-      { userId: senderId, role: sender.role }, // ή userId αν έτσι το περιμένεις
+    // Owner is sender here because of the new rules. Owner has to send first msg
+    const ownerToken = jwt.sign(
+      { userId: receiverId, role: receiver.role },
       process.env.JWT_SECRET,
       { expiresIn: "7d" }
     );
@@ -97,9 +98,9 @@ const property = await Property.create({
 
     const res = await request(app)
       .post("/api/messages")
-      .set("Authorization", `Bearer ${senderToken}`)
+      .set("Authorization", `Bearer ${ownerToken}`)
       .send({
-        receiverId,
+        receiverId: senderId, // sending to client
         propertyId,
         content,
       })
@@ -111,8 +112,8 @@ const property = await Property.create({
 
     // 6) Ελέγχουμε την HTTP απόκριση
     expect(body.content).toBe(content);
-    expect(getId(body.sender || body.senderId)).toBe(senderId);
-    expect(getId(body.receiver || body.receiverId)).toBe(receiverId);
+    expect(getId(body.sender || body.senderId)).toBe(receiverId); // receiver is now the owner
+    expect(getId(body.receiver || body.receiverId)).toBe(senderId); // sender is now the client
     expect(getId(body.property || body.propertyId)).toBe(propertyId);
 
     // 7) Ελέγχουμε ότι αποθηκεύτηκε στη βάση
@@ -120,29 +121,30 @@ const property = await Property.create({
     expect(allMessages.length).toBe(1);
     expect(allMessages[0].content).toBe(content);
     expect(String(allMessages[0].sender || allMessages[0].senderId)).toBe(
-      senderId
+      receiverId
     );
     expect(String(allMessages[0].receiver || allMessages[0].receiverId)).toBe(
-      receiverId
+      senderId
     );
     expect(String(allMessages[0].property || allMessages[0].propertyId)).toBe(
       propertyId
     );
 
     // 8) Ελέγχουμε ότι έκανε emit σε ΔΥΟ rooms: receiverId & senderId
-    expect(emitted.length).toBe(2);
+    const messageEmits = emitted.filter((e) => e.event === "newMessage");
+    expect(messageEmits.length).toBe(2);
 
-    const rooms = emitted.map((e) => e.roomId);
+    const rooms = messageEmits.map((e) => e.roomId);
     expect(rooms).toContain(receiverId);
     expect(rooms).toContain(senderId);
 
-    emitted.forEach((e) => {
+    messageEmits.forEach((e) => {
       expect(e.event).toBe("newMessage");
       expect(e.payload.content).toBe(content);
 
       const p = e.payload;
-      expect(getId(p.sender || p.senderId)).toBe(senderId);
-      expect(getId(p.receiver || p.receiverId)).toBe(receiverId);
+      expect(getId(p.sender || p.senderId)).toBe(receiverId);
+      expect(getId(p.receiver || p.receiverId)).toBe(senderId);
       expect(getId(p.property || p.propertyId)).toBe(propertyId);
     });
   });

--- a/backend/backend.log
+++ b/backend/backend.log
@@ -1,0 +1,45 @@
+
+> backend@1.0.0 start
+> node server.js
+
+[dotenv@17.2.3] injecting env (5) from .env -- tip: 🔑 add access controls to secrets: https://dotenvx.com/ops
+✅ Environment variables validated
+[dotenv@17.2.3] injecting env (0) from .env -- tip: 🔐 encrypt with Dotenvx: https://dotenvx.com
+Mailer is not configured. Set MAIL_* (or SMTP_*) env vars to enable forgot-password emails.
+⚠️ Cloudinary env vars are missing. Falling back to local /uploads storage.
+==loading controller from: /app/backend/controllers/favoritesController
+(node:153645) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+(Use `node --trace-deprecation ...` to show where the warning was created)
+Failed to start server: MongooseServerSelectionError: connect ECONNREFUSED ::1:27017, connect ECONNREFUSED 127.0.0.1:27017
+    at _handleConnectionErrors (/app/backend/node_modules/mongoose/lib/connection.js:1165:11)
+    at NativeConnection.openUri (/app/backend/node_modules/mongoose/lib/connection.js:1096:11)
+    at async start (/app/backend/server.js:78:7) {
+  errorLabelSet: Set(0) {},
+  reason: TopologyDescription {
+    type: 'Unknown',
+    servers: Map(1) { 'localhost:27017' => [ServerDescription] },
+    stale: false,
+    compatible: true,
+    heartbeatFrequencyMS: 10000,
+    localThresholdMS: 15,
+    setName: null,
+    maxElectionId: null,
+    maxSetVersion: null,
+    commonWireVersion: 0,
+    logicalSessionTimeoutMinutes: null
+  },
+  code: undefined,
+  cause: TopologyDescription {
+    type: 'Unknown',
+    servers: Map(1) { 'localhost:27017' => [ServerDescription] },
+    stale: false,
+    compatible: true,
+    heartbeatFrequencyMS: 10000,
+    localThresholdMS: 15,
+    setName: null,
+    maxElectionId: null,
+    maxSetVersion: null,
+    commonWireVersion: 0,
+    logicalSessionTimeoutMinutes: null
+  }
+}

--- a/backend/controllers/matchController.js
+++ b/backend/controllers/matchController.js
@@ -219,6 +219,9 @@ const scoreRequirementsVsTenant = (tenantReq = {}, user = {}) => {
   return { score, checks, fails };
 };
 
+exports.scorePrefsVsProperty = scorePrefsVsProperty;
+exports.scoreRequirementsVsTenant = scoreRequirementsVsTenant;
+
 /* ------------------------ controller ------------------------- */
 exports.findMatchingProperties = async (req, res) => {
   try {
@@ -302,6 +305,85 @@ exports.findMatchingProperties = async (req, res) => {
     res.json(results);
   } catch (error) {
     console.error("Error finding matching properties:", error);
+    res.status(500).json({ message: "Server error" });
+  }
+};
+
+exports.findMatchingClients = async (req, res) => {
+  try {
+    const ownerId = req.user.userId;
+    const user = await User.findById(ownerId).select("-password").lean();
+
+    if (!user || user.role !== "owner") {
+      return res.status(403).json({ message: "Only owners can view matched clients" });
+    }
+
+    // Find properties of the owner
+    const ownerProperties = await Property.find({ ownerId }).lean({ virtuals: true });
+
+    if (!ownerProperties.length) {
+      return res.json([]);
+    }
+
+    // Find all active clients
+    const clients = await User.find({ role: "client", onboardingCompleted: true }).select("-password").lean();
+
+    const matchedClientsMap = new Map();
+
+    for (const client of clients) {
+      const preferences = client.preferences || {};
+
+      for (const prop of ownerProperties) {
+        const propertyData = {
+          _id: prop._id,
+          type: prop.type,
+          location: prop.location,
+          price: prop.price ?? prop.rent,
+          squareMeters: prop.squareMeters ?? prop.sqm,
+          bedrooms: prop.bedrooms,
+          bathrooms: prop.bathrooms,
+          floor: prop.floor,
+          yearBuilt: prop.yearBuilt,
+          furnished: prop.furnished,
+          hasElevator: prop.hasElevator ?? prop.elevator,
+          parkingSpaces: prop.parkingSpaces ?? (prop.parking ? 1 : 0),
+          petsAllowed: prop.petsAllowed,
+          smokingAllowed: prop.smokingAllowed,
+          heating: prop.heating ?? prop.heatingType,
+        };
+
+        const prefScore = scorePrefsVsProperty(preferences, propertyData);
+        const tenantReqs = prop.tenantRequirements || {};
+        const tenantScore = scoreRequirementsVsTenant(tenantReqs, client);
+
+        if (prefScore.score >= MIN_MATCH_COUNT && tenantScore.score >= MIN_MATCH_COUNT) {
+          const combined = prefScore.score + tenantScore.score;
+
+          if (!matchedClientsMap.has(client._id)) {
+            matchedClientsMap.set(client._id, {
+              ...client,
+              matchedPropertyId: prop._id,
+              combinedScore: combined
+            });
+          } else {
+             // If they match multiple properties, keep the highest score
+             if (combined > matchedClientsMap.get(client._id).combinedScore) {
+               matchedClientsMap.set(client._id, {
+                 ...client,
+                 matchedPropertyId: prop._id,
+                 combinedScore: combined
+               });
+             }
+          }
+        }
+      }
+    }
+
+    const results = Array.from(matchedClientsMap.values()).sort((a, b) => b.combinedScore - a.combinedScore);
+
+    res.json(results);
+  } catch (error) {
+    console.error("Error finding matching clients:", error);
     res.status(500).json({ message: "Server error" });
   }
 };

--- a/backend/controllers/messageController.js
+++ b/backend/controllers/messageController.js
@@ -12,6 +12,19 @@ exports.sendMessage = async (req, res) => {
   }
 
   try {
+    // Check if it's the first message
+    const existingMessages = await Message.countDocuments({
+      propertyId,
+      $or: [
+        { senderId, receiverId },
+        { senderId: receiverId, receiverId: senderId }
+      ]
+    });
+
+    if (existingMessages === 0 && req.user.role !== "owner") {
+      return res.status(403).json({ message: "Only owners can send the first message to a client." });
+    }
+
     let newMessage = new Message({ senderId, receiverId, propertyId, content, readBy: [senderId] });
     await newMessage.save();
 
@@ -24,6 +37,36 @@ exports.sendMessage = async (req, res) => {
       io.to(receiverId).emit('newMessage', newMessage);
       // Emit to sender's room, for UI sync across multiple devices/tabs
       io.to(senderId).emit('newMessage', newMessage);
+    }
+
+    if (existingMessages === 0 && req.user.role === "owner") {
+      try {
+        const Notification = require("../models/notification");
+
+        // Property title might be needed
+        let propertyTitle = "Unknown Property";
+        if (newMessage.propertyId && newMessage.propertyId.title) {
+           propertyTitle = newMessage.propertyId.title;
+        } else {
+           const Property = require("../models/property");
+           const p = await Property.findById(propertyId).lean();
+           if (p && p.title) propertyTitle = p.title;
+        }
+
+        const notification = await Notification.create({
+          userId: receiverId,
+          type: "message",
+          referenceId: propertyId,
+          senderId: senderId,
+          message: `An owner has selected you and sent you a message for property "${propertyTitle}".`
+        });
+
+        if (io) {
+          io.to(String(receiverId)).emit("notification", notification);
+        }
+      } catch (notifErr) {
+        console.error("Error creating notification for first message:", notifErr);
+      }
     }
 
     res.status(201).json(newMessage);

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -324,6 +324,88 @@ exports.saveOnboarding = async (req, res) => {
     doc.onboardingCompleted = true;
 
     await doc.save();
+
+    // Check for matches with owner properties and create notifications
+    if (doc.role === "client") {
+      try {
+        const Property = require("../models/property");
+        const Notification = require("../models/notification");
+        const matchController = require("./matchController");
+
+        // Optimization: Find active properties that potentially match, then properly evaluate
+        // Using same mapping as matchController
+        const dbMatch = { status: "available" };
+        if (doc.preferences?.dealType) dbMatch.type = doc.preferences.dealType;
+        if (doc.preferences?.location) dbMatch.location = { $regex: doc.preferences.location, $options: "i" };
+
+        const maxBudget =
+          doc.preferences?.dealType === "rent"
+            ? doc.preferences.rentMax
+            : (doc.preferences?.priceMax ?? doc.preferences?.saleMax);
+
+        if (maxBudget !== undefined) {
+          dbMatch.$or = [
+            { price: { $lte: Number(maxBudget) } },
+            { rent: { $lte: Number(maxBudget) } }
+          ];
+        }
+
+        const properties = await Property.find(dbMatch).lean({ virtuals: true });
+
+        const ownerMatches = new Set();
+
+        for (const prop of properties) {
+          const propertyData = {
+            _id: prop._id,
+            type: prop.type,
+            location: prop.location,
+            price: prop.price ?? prop.rent,
+            squareMeters: prop.squareMeters ?? prop.sqm,
+            bedrooms: prop.bedrooms,
+            bathrooms: prop.bathrooms,
+            floor: prop.floor,
+            yearBuilt: prop.yearBuilt,
+            furnished: prop.furnished,
+            hasElevator: prop.hasElevator ?? prop.elevator,
+            parkingSpaces: prop.parkingSpaces ?? (prop.parking ? 1 : 0),
+            petsAllowed: prop.petsAllowed,
+            smokingAllowed: prop.smokingAllowed,
+            heating: prop.heating ?? prop.heatingType,
+          };
+
+          const tenantReqs = prop.tenantRequirements || {};
+          const tenantScore = matchController.scoreRequirementsVsTenant ? matchController.scoreRequirementsVsTenant(tenantReqs, doc) : { score: 0 };
+          const prefScore = matchController.scorePrefsVsProperty ? matchController.scorePrefsVsProperty(doc.preferences || {}, propertyData) : { score: 0 };
+
+          // MIN_MATCH_COUNT from matchController is 2
+          if (prefScore.score >= 2 && tenantScore.score >= 2) {
+            ownerMatches.add(String(prop.ownerId));
+          }
+        }
+
+        const notifications = Array.from(ownerMatches).map(ownerId => ({
+          userId: ownerId,
+          type: "match",
+          referenceId: doc._id,
+          senderId: doc._id,
+          message: `A new client matching your property requirements has registered.`
+        }));
+
+        if (notifications.length > 0) {
+           const created = await Notification.insertMany(notifications);
+           const io = req.app.get('io');
+           if (io) {
+             created.forEach(n => {
+               io.to(String(n.userId)).emit('notification', n);
+             });
+           }
+        }
+
+      } catch (matchErr) {
+        console.error("Error creating match notifications during onboarding:", matchErr);
+      }
+    }
+
     res.json({ message: "Onboarding saved", user: buildUserResponse(doc) });
   } catch (err) {
     console.error("saveOnboarding error:", err);

--- a/backend/routes/properties.js
+++ b/backend/routes/properties.js
@@ -11,6 +11,11 @@ const { uploadFields } = require("../middlewares/uploadMiddleware");
 const propertyController = require("../controllers/propertyController");
 
 // ------------------------------------------------------------------
+const matchController = require("../controllers/matchController");
+
+// Match Clients
+router.get("/match/clients", verifyToken, matchController.findMatchingClients);
+
 // Public listing (optional auth: αν υπάρχει token, γεμίζει req.currentUser
 // ώστε να δουλέψει το client matching στον controller)
 router.get("/", optionalAuth, propertyController.getAllProperties);

--- a/frontend/frontend.log
+++ b/frontend/frontend.log
@@ -1,0 +1,29 @@
+
+> frontend@1.0.0 start
+> react-scripts start
+
+Browserslist: browsers data (caniuse-lite) is 8 months old. Please run:
+  npx update-browserslist-db@latest
+  Why you should do it regularly: https://github.com/browserslist/update-db#readme
+(node:129563) [DEP_WEBPACK_DEV_SERVER_ON_AFTER_SETUP_MIDDLEWARE] DeprecationWarning: 'onAfterSetupMiddleware' option is deprecated. Please use the 'setupMiddlewares' option.
+(Use `node --trace-deprecation ...` to show where the warning was created)
+(node:129563) [DEP_WEBPACK_DEV_SERVER_ON_BEFORE_SETUP_MIDDLEWARE] DeprecationWarning: 'onBeforeSetupMiddleware' option is deprecated. Please use the 'setupMiddlewares' option.
+Starting the development server...
+
+Compiled successfully!
+
+You can now view frontend in the browser.
+
+  Local:            http://localhost:3000
+  On Your Network:  http://192.168.0.2:3000
+
+Note that the development build is not optimized.
+To create a production build, use npm run build.
+
+webpack compiled successfully
+(node:129563) [DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.
+Proxy error: Could not proxy request /api/auth/login from localhost:3000 to http://localhost:5000.
+See https://nodejs.org/api/errors.html#errors_common_system_errors for more information (ECONNREFUSED).
+
+Proxy error: Could not proxy request /api/auth/login from localhost:3000 to http://localhost:5000.
+See https://nodejs.org/api/errors.html#errors_common_system_errors for more information (ECONNREFUSED).

--- a/frontend/src/pages/MatchClients.js
+++ b/frontend/src/pages/MatchClients.js
@@ -10,7 +10,7 @@ function MatchClients() {
     const fetchClients = async () => {
       try {
         const token = localStorage.getItem('token');
-        const res = await api.get('/match/clients', {
+        const res = await api.get('/properties/match/clients', {
           headers: { Authorization: `Bearer ${token}` }
         });
         const data = Array.isArray(res.data) ? res.data : [];
@@ -48,7 +48,7 @@ function MatchClients() {
                 </div>
                 <button
                   className="mt-auto btn btn-primary"
-                  onClick={() => navigate('/messages')}
+                  onClick={() => navigate(`/chat/${c.matchedPropertyId}/${c._id}`)}
                 >
                   Message
                 </button>


### PR DESCRIPTION
This PR implements the requested client matching logic and messaging restrictions.

1. **Owner Notified on Match**: When a client completes onboarding, the backend evaluates all available properties. If the client matches any owner's `tenantRequirements` and property `preferences` (with a score of at least 2 each), a notification is triggered and sent to the owner(s).
2. **Match Clients Page**: The owner can navigate to a "Suggested Tenants" (`MatchClients`) page. A new backend route, `GET /api/properties/match/clients`, evaluates the owner's properties against all active clients, and returns the matches sorted by combined score. The frontend redirects the owner to the chat correctly upon clicking "Message" (`/chat/:propertyId/:clientId`).
3. **Owner-First Messaging**: In `messageController.js`, a check blocks the creation of the first message in any conversation thread if the sender is not an `owner`.
4. **Client Notification on Message**: When an owner successfully sends the first message to a client, the backend automatically generates a notification to inform the client that they have been selected and messaged by an owner, including the relevant property's title.

---
*PR created automatically by Jules for task [6486839919761130083](https://jules.google.com/task/6486839919761130083) started by @ElpiDim*