### PR TITLE
Fix owner real-time match notification delivery

### DIFF
--- a/frontend/src/context/SocketContext.jsx
+++ b/frontend/src/context/SocketContext.jsx
@@ -16,9 +16,12 @@ export const SocketProvider = ({ children }) => {
 
     const s = createSocket(token);
 
+    const userRoomId = user?._id || user?.id;
+
     s.on("connect", () => {
-      s.emit("join", user.id); // join personal room
-      console.log("🔌 Socket connected and joined room:", user.id);
+      if (!userRoomId) return;
+      s.emit("join", userRoomId); // join personal room
+      console.log("🔌 Socket connected and joined room:", userRoomId);
     });
 
     // 👉 REAL-TIME NOTIFICATIONS
@@ -44,7 +47,7 @@ export const SocketProvider = ({ children }) => {
       s.off("newMessage");
       s.disconnect();
     };
-  }, [user?.id, token]);
+  }, [user?._id, user?.id, token]);
 
   return (
     <SocketContext.Provider value={socket}>


### PR DESCRIPTION
### Motivation
- Owners were not receiving real-time `notification` events because the frontend emitted `join` with `user.id` while backend emits target the Mongo `ownerId` (stored as `user._id`), causing sockets to join the wrong/empty room.

### Description
- Updated `SocketContext.jsx` to compute `userRoomId = user?._id || user?.id`, only emit `join` when a valid id exists, and added `_id`/`id` to the `useEffect` dependencies so the socket re-joins when the effective id changes.

### Testing
- Ran frontend tests with `npm --prefix frontend run test -- --watchAll=false`, which failed in the current environment because `react-scripts` is not installed (`sh: 1: react-scripts: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20da84b9483228e180353fb8a55a3)