### PR TITLE
Socket: robust URL resolution, transport fallback, and user ID handling

### DIFF
--- a/frontend/src/context/SocketContext.jsx
+++ b/frontend/src/context/SocketContext.jsx
@@ -16,9 +16,12 @@ export const SocketProvider = ({ children }) => {
 
     const s = createSocket(token);
 
+    const userRoomId = user?._id || user?.id;
+
     s.on("connect", () => {
-      s.emit("join", user.id); // join personal room
-      console.log("🔌 Socket connected and joined room:", user.id);
+      if (!userRoomId) return;
+      s.emit("join", userRoomId); // join personal room
+      console.log("🔌 Socket connected and joined room:", userRoomId);
     });
 
     // 👉 REAL-TIME NOTIFICATIONS
@@ -44,7 +47,7 @@ export const SocketProvider = ({ children }) => {
       s.off("newMessage");
       s.disconnect();
     };
-  }, [user?.id, token]);
+  }, [user?._id, user?.id, token]);
 
   return (
     <SocketContext.Provider value={socket}>

--- a/frontend/src/socket.js
+++ b/frontend/src/socket.js
@@ -1,9 +1,31 @@
 // src/socket.js
 import { io } from "socket.io-client";
 
+const stripTrailingSlashes = (value = "") => String(value).replace(/\/+$/, "");
+
+const resolveSocketBaseUrl = () => {
+  const explicitBackend = stripTrailingSlashes(process.env.REACT_APP_BACKEND_URL);
+  if (explicitBackend) return explicitBackend;
+
+  const apiUrl = stripTrailingSlashes(process.env.REACT_APP_API_URL);
+  if (apiUrl) {
+    // REACT_APP_API_URL is often like https://host/api -> socket server is https://host
+    return apiUrl.replace(/\/api$/i, "");
+  }
+
+  if (typeof window !== "undefined" && window.location?.origin) {
+    return window.location.origin;
+  }
+
+  return "http://localhost:5000";
+};
+
 export const createSocket = (token) => {
-  return io(process.env.REACT_APP_BACKEND_URL || "http://localhost:5000", {
-    transports: ["websocket"],
+  const baseUrl = resolveSocketBaseUrl();
+
+  return io(baseUrl, {
+    // Keep polling fallback for environments where pure websocket upgrade fails.
+    transports: ["websocket", "polling"],
     auth: { token },
   });
 };


### PR DESCRIPTION
### Motivation

- Prevent socket setup from failing when the authenticated user object uses `_id` instead of `id` or is temporarily falsy.
- Make socket server URL resolution resilient across different environment variable configurations and deployment patterns.
- Improve connection reliability in environments where pure WebSocket upgrade may fail.

### Description

- Update `SocketContext.jsx` to compute `userRoomId` from `user._id` or `user.id`, guard against missing user values before emitting `join`, and include both `user?._id` and `user?.id` in the effect dependencies.
- Add `resolveSocketBaseUrl` and `stripTrailingSlashes` helpers in `frontend/src/socket.js` to prefer `REACT_APP_BACKEND_URL`, fall back to `REACT_APP_API_URL` (stripping a trailing `/api`), then `window.location.origin`, and finally `http://localhost:5000` as a last resort.
- Change `createSocket` to use the resolved base URL and add `polling` to transports so connections can fall back when websocket-only fails, while still sending the `token` via `auth`.
- Ensure socket event handlers (`notification`, `newMessage`) are registered and cleaned up as before and that sockets are disconnected when token/user are absent.

### Testing

- No automated tests were added or modified for this change.
- Existing automated test suite was not executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20da84b9483228e180353fb8a55a3)