### PR TITLE
Show owner match popup from notification with accept/reject actions

### DIFF
--- a/frontend/src/components/NotificationDropdown.js
+++ b/frontend/src/components/NotificationDropdown.js
@@ -46,6 +46,8 @@ export default function NotificationsDropdown({
 
   const [open, setOpen] = useState(false);
   const [notifications, setNotifications] = useState([]);
+  const [matchPopup, setMatchPopup] = useState(null);
+  const [matchActionLoading, setMatchActionLoading] = useState(false);
   const unreadCount = useMemo(
     () => notifications.filter((n) => !(n.readAt || n.read)).length,
     [notifications]
@@ -179,8 +181,47 @@ export default function NotificationsDropdown({
       return;
     }
 
+    if ((note.type || "").toLowerCase() === "match_pending") {
+      try {
+        const res = await api.get("/matches/owner/pending", {
+          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+        });
+        const pending = Array.isArray(res.data) ? res.data : [];
+        const matchId = note?.referenceId?._id || note?.referenceId;
+        const selectedMatch = pending.find((m) => String(m?._id) === String(matchId));
+        if (selectedMatch) {
+          setMatchPopup(selectedMatch);
+          return;
+        }
+      } catch (e) {
+        console.error("fetch pending matches failed", e);
+      }
+      navigate("/dashboard/owner/matches");
+      return;
+    }
+
     if (note.referenceId) {
       navigate(`/property/${note.referenceId}`);
+    }
+  };
+
+  const handleMatchAction = async (status) => {
+    if (!matchPopup?._id || matchActionLoading) return;
+    setMatchActionLoading(true);
+    try {
+      await api.patch(
+        `/matches/${matchPopup._id}/status`,
+        { status },
+        {
+          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+        }
+      );
+      setMatchPopup(null);
+      fetchNotifications();
+    } catch (e) {
+      console.error(`match ${status} failed`, e);
+    } finally {
+      setMatchActionLoading(false);
     }
   };
 
@@ -255,6 +296,36 @@ export default function NotificationsDropdown({
                 }}
               >
                 View all
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      {matchPopup && (
+        <div className="nd-modalBackdrop" role="presentation" onClick={() => !matchActionLoading && setMatchPopup(null)}>
+          <div className="nd-matchModal" role="dialog" aria-modal="true" onClick={(e) => e.stopPropagation()}>
+            <h4 className="nd-matchTitle">Potential New Match</h4>
+            <p className="nd-matchText">
+              <strong>Client:</strong> {matchPopup?.clientId?.name || "Unknown"}
+            </p>
+            <p className="nd-matchText">
+              <strong>Email:</strong> {matchPopup?.clientId?.email || "Not available"}
+            </p>
+            <p className="nd-matchText">
+              <strong>Phone:</strong> {matchPopup?.clientId?.phone || "Not available"}
+            </p>
+            <p className="nd-matchText">
+              <strong>Occupation:</strong> {matchPopup?.clientId?.occupation || "Not available"}
+            </p>
+            <p className="nd-matchText">
+              <strong>Property:</strong> {matchPopup?.propertyId?.title || "Property"}
+            </p>
+            <div className="nd-matchActions">
+              <button type="button" className="nd-matchBtn reject" onClick={() => handleMatchAction("rejected")} disabled={matchActionLoading}>
+                Reject
+              </button>
+              <button type="button" className="nd-matchBtn accept" onClick={() => handleMatchAction("accepted")} disabled={matchActionLoading}>
+                Accept
               </button>
             </div>
           </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -538,3 +538,53 @@ code { font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', mon
   color: var(--primary);
   font-weight: 800;
 }
+
+.nd-modalBackdrop{
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1200;
+}
+.nd-matchModal{
+  width: min(92vw, 460px);
+  background: #fff;
+  border-radius: 14px;
+  padding: 20px;
+  box-shadow: 0 20px 50px rgba(0,0,0,0.2);
+}
+.nd-matchTitle{
+  margin: 0 0 12px;
+  color: #2a2140;
+}
+.nd-matchText{
+  margin: 6px 0;
+  color: #4a4860;
+}
+.nd-matchActions{
+  margin-top: 18px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+.nd-matchBtn{
+  border: none;
+  border-radius: 10px;
+  padding: 10px 16px;
+  font-weight: 700;
+  cursor: pointer;
+}
+.nd-matchBtn.reject{
+  background: #ffe7ea;
+  color: #a22035;
+}
+.nd-matchBtn.accept{
+  background: #e4f9ee;
+  color: #1f7d42;
+}
+.nd-matchBtn:disabled{
+  opacity: 0.65;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
### Motivation
- Owners receiving a `match_pending` notification should be able to inspect the client and property details immediately and accept or reject the match without navigating away. 

### Description
- Added owner match handling in the notifications dropdown component by fetching `/matches/owner/pending` and opening an inline modal when a `match_pending` notification is clicked. 
- Implemented modal UI and actions (`Accept` / `Reject`) that call the existing backend endpoint `PATCH /matches/:matchId/status` and refresh notifications after success. 
- Added local component state for `matchPopup` and `matchActionLoading` and wired optimistic read marking in `NotificationDropdown`. 
- Added modal styling to `frontend/src/index.css` and updated `frontend/src/components/NotificationDropdown.js` to render the popup and perform API calls. 

### Testing
- Ran a production frontend build with `npm --prefix frontend run build`, which compiled successfully and produced the build artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f30a6e35ec83228c3a068543bb9cbf)